### PR TITLE
Rename project to gooseBit & mention DDI API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# goosebit
+# gooseBit
 <img src="docs/img/goosebit-logo.png" style="width: 100px; height: 100px; display: block;">
 
 ---
@@ -8,9 +8,9 @@ A simplistic remote update server.
 
 ## Setup
 
-To set up, install the dependencies in `pyproject.toml` with `poetry install`.  Then you can run GooseBit by running `main.py`.
+To set up, install the dependencies in `pyproject.toml` with `poetry install`.  Then you can run gooseBit by running `main.py`.
 
 ## Initial Startup
 
-The first time you start GooseBit, you should change the default username and password inside `settings.yaml`.
+The first time you start gooseBit, you should change the default username and password inside `settings.yaml`.
 The default login credentials for testing are `admin@goosebit.local`, `admin`.

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ---
 
-A simplistic remote update server.
+A simplistic remote update server implementing hawkBit™'s [DDI API](https://eclipse.dev/hawkbit/apis/ddi_api/).
 
 
 ## Setup

--- a/goosebit/ui/templates/nav.html
+++ b/goosebit/ui/templates/nav.html
@@ -34,7 +34,7 @@
             <div class="container-fluid">
                 <a class="navbar-brand" href="/ui/home">
                     <img src="{{ request.url_for('static', path='svg/goosebit-logo.svg') }}" class="me-2" style="height:30px; width: 30px;"/>
-                    GooseBit
+                    gooseBit
                 </a>
                 <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbar" aria-controls="navbar" aria-expanded="false" aria-label="Toggle navigation">
                     <span class="navbar-toggler-icon"></span>


### PR DESCRIPTION
Let's use the same style as hawkBit for the "friendly name". The repository, files, and the Python package shall remain all-lowercase.