### PR TITLE
Persist fw_version once installation got confirmed

### DIFF
--- a/goosebit/updater/controller/v1/routes.py
+++ b/goosebit/updater/controller/v1/routes.py
@@ -79,6 +79,9 @@ async def deployment_feedback(
     try:
         state = data["status"]["result"]["finished"]
         await updater.update_device_state(state)
+        if state == "success":
+            file = await updater.get_update_file()
+            await updater.update_fw_version(file.name)
     except KeyError:
         pass
 


### PR DESCRIPTION
After a successful update, the fw_version should be set to the image name. This will prevent an endless loop of device updates.