### PR TITLE
Polling should not return deployment base if device is up-to-date

### DIFF
--- a/goosebit/updater/controller/v1/routes.py
+++ b/goosebit/updater/controller/v1/routes.py
@@ -16,17 +16,23 @@ async def polling(
     dev_id: str,
     updater: UpdateManager = Depends(get_update_manager),
 ):
-    return {
-        "config": {"polling": {"sleep": updater.poll_time}},
-        "_links": {
+    update = await updater.get_update_mode()
+    if update == "skip":
+        deployment = {}
+    else:
+        deployment = {
             "deploymentBase": {
                 "href": str(
                     request.url_for(
                         "deployment_base", tenant=tenant, dev_id=dev_id, action_id=1
                     )
                 )
-            },
-        },
+            }
+        }
+
+    return {
+        "config": {"polling": {"sleep": updater.poll_time}},
+        "_links": deployment,
     }
 
 


### PR DESCRIPTION
swupdate did four calls for every poll. Not returning a deploymentBase if state will be skip reduces it to a single call.