### PR TITLE
Support for multiple device types and more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,7 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 .idea/
+
+# application files
+/updates
+/db.sqlite3*

--- a/goosebit/api/devices.py
+++ b/goosebit/api/devices.py
@@ -33,6 +33,8 @@ async def devices_get_all() -> list[dict]:
             "name": device.name,
             "fw": device.fw_version,
             "fw_file": device.fw_file,
+            "hw_model": device.hw_model,
+            "hw_revision": device.hw_revision,
             "state": device.last_state,
             "force_update": manager.force_update,
             "last_ip": device.last_ip,

--- a/goosebit/api/firmware.py
+++ b/goosebit/api/firmware.py
@@ -37,19 +37,6 @@ async def firmware_get_all() -> list[dict]:
     return firmware
 
 
-@router.get(
-    "/latest",
-    dependencies=[
-        Security(validate_user_permissions, scopes=[Permissions.FIRMWARE.READ])
-    ],
-)
-async def firmware_get_latest() -> dict:
-    UPDATES_DIR.mkdir(parents=True, exist_ok=True)
-
-    file_data = UPDATES_DIR.joinpath(get_newest_fw())
-    return {"name": file_data.name, "size": file_data.stat().st_size}
-
-
 @router.post(
     "/delete",
     dependencies=[

--- a/goosebit/api/firmware.py
+++ b/goosebit/api/firmware.py
@@ -4,7 +4,7 @@ from fastapi.requests import Request
 from goosebit.auth import validate_user_permissions
 from goosebit.permissions import Permissions
 from goosebit.settings import UPDATES_DIR
-from goosebit.updater.misc import fw_sort_key, get_newest_fw
+from goosebit.updater.misc import fw_sort_key
 from goosebit.updater.updates import FirmwareArtifact
 
 router = APIRouter(prefix="/firmware")

--- a/goosebit/models.py
+++ b/goosebit/models.py
@@ -11,6 +11,8 @@ class Device(Model):
     name = fields.CharField(max_length=255, null=True)
     fw_file = fields.CharField(max_length=255, default="latest")
     fw_version = fields.CharField(max_length=255, null=True)
+    hw_model = fields.CharField(max_length=255, null=True, default="default")
+    hw_revision = fields.CharField(max_length=255, null=True, default="default")
     last_state = fields.CharField(max_length=255, null=True)
     last_log = fields.TextField(null=True)
     last_seen = fields.BigIntField(null=True)

--- a/goosebit/models.py
+++ b/goosebit/models.py
@@ -13,7 +13,7 @@ class Device(Model):
     fw_version = fields.CharField(max_length=255, null=True)
     hw_model = fields.CharField(max_length=255, null=True, default="default")
     hw_revision = fields.CharField(max_length=255, null=True, default="default")
-    last_state = fields.CharField(max_length=255, null=True)
+    last_state = fields.CharField(max_length=255, null=True, default="unknown")
     last_log = fields.TextField(null=True)
     last_seen = fields.BigIntField(null=True)
     last_ip = fields.CharField(max_length=15, null=True)

--- a/goosebit/ui/static/js/devices.js
+++ b/goosebit/ui/static/js/devices.js
@@ -40,6 +40,8 @@ document.addEventListener("DOMContentLoaded", function() {
                 }
             },
             { data: 'uuid' },
+            { data: 'hw_model' },
+            { data: 'hw_revision' },
             { data: 'fw' },
             {
                 data: 'force_update',

--- a/goosebit/ui/templates/devices.html
+++ b/goosebit/ui/templates/devices.html
@@ -16,6 +16,12 @@
                             UUID
                         </th>
                         <th>
+                            Model
+                        </th>
+                        <th>
+                            Revision
+                        </th>
+                        <th>
                             Firmware
                         </th>
                         <th>

--- a/goosebit/updater/download/v1/routes.py
+++ b/goosebit/updater/download/v1/routes.py
@@ -12,15 +12,3 @@ router = APIRouter(prefix="/v1")
 async def download_file(request: Request, tenant: str, dev_id: str, file: str):
     filename = UPDATES_DIR.joinpath(file)
     return FileResponse(filename, media_type="application/octet-stream")
-
-
-@router.get("/{dev_id}/cfd_conf/{file}")
-async def download_cfd_conf(
-    request: Request,
-    tenant: str,
-    dev_id: str,
-    file: str,
-    updater: UpdateManager = Depends(get_update_manager),
-):
-    filename = TOKEN_SWU_DIR.joinpath(dev_id, file)
-    return FileResponse(filename, media_type="application/octet-stream")

--- a/goosebit/updater/manager.py
+++ b/goosebit/updater/manager.py
@@ -8,7 +8,6 @@ from typing import Callable
 
 from goosebit.models import Device
 from goosebit.settings import POLL_TIME, POLL_TIME_UPDATING
-from goosebit.updater.misc import get_newest_fw
 from goosebit.updater.updates import FirmwareArtifact
 
 
@@ -80,7 +79,7 @@ class UnknownUpdateManager(UpdateManager):
         self.poll_time = POLL_TIME_UPDATING
 
     async def get_update_file(self) -> FirmwareArtifact:
-        return FirmwareArtifact(get_newest_fw())
+        return FirmwareArtifact("latest")
 
     async def get_update_mode(self) -> str:
         return "forced"

--- a/goosebit/updater/manager.py
+++ b/goosebit/updater/manager.py
@@ -30,6 +30,12 @@ class UpdateManager(ABC):
     async def update_fw_version(self, version: str) -> None:
         return
 
+    async def update_hw_model(self, hw_model: str) -> None:
+        return
+
+    async def update_hw_revision(self, hw_revision: str) -> None:
+        return
+
     async def update_device_state(self, state: str) -> None:
         return
 
@@ -40,6 +46,10 @@ class UpdateManager(ABC):
         return
 
     async def update_config_data(self, **kwargs):
+        await self.update_hw_model(kwargs.get("hw_model") or "default")
+        await self.update_hw_revision(kwargs.get("hw_revision") or "default")
+        await self.save()
+
         self.config_data.update(kwargs)
 
     @asynccontextmanager
@@ -102,6 +112,14 @@ class DeviceUpdateManager(UpdateManager):
         device = await self.get_device()
         device.fw_version = version
 
+    async def update_hw_model(self, hw_model: str) -> None:
+        device = await self.get_device()
+        device.hw_model = hw_model
+
+    async def update_hw_revision(self, hw_revision: str) -> None:
+        device = await self.get_device()
+        device.hw_revision = hw_revision
+
     async def update_device_state(self, state: str) -> None:
         device = await self.get_device()
         device.last_state = state
@@ -119,7 +137,7 @@ class DeviceUpdateManager(UpdateManager):
 
     async def get_update_file(self) -> FirmwareArtifact:
         device = await self.get_device()
-        file = FirmwareArtifact(device.fw_file)
+        file = FirmwareArtifact(device.fw_file, device.hw_model, device.hw_revision)
 
         if self.force_update:
             return file

--- a/goosebit/updater/manager.py
+++ b/goosebit/updater/manager.py
@@ -48,6 +48,7 @@ class UpdateManager(ABC):
     async def update_config_data(self, **kwargs):
         await self.update_hw_model(kwargs.get("hw_model") or "default")
         await self.update_hw_revision(kwargs.get("hw_revision") or "default")
+        await self.update_device_state("registered")
         await self.save()
 
         self.config_data.update(kwargs)
@@ -151,6 +152,9 @@ class DeviceUpdateManager(UpdateManager):
             mode = "skip"
             self.poll_time = POLL_TIME
         elif file.name == device.fw_version:
+            mode = "skip"
+            self.poll_time = POLL_TIME
+        elif device.last_state == "failure":
             mode = "skip"
             self.poll_time = POLL_TIME
         else:

--- a/goosebit/updater/misc.py
+++ b/goosebit/updater/misc.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import datetime
 import hashlib
 from pathlib import Path
+from typing import Optional
 
 from goosebit.models import Device
 from goosebit.settings import UPDATES_DIR
@@ -14,10 +15,10 @@ def sha1_hash_file(file_path: Path):
     return sha1_hash.hexdigest()
 
 
-def get_newest_fw() -> str:
+def get_newest_fw() -> Optional[str]:
     fw_files = [f for f in UPDATES_DIR.iterdir() if f.suffix == ".swu"]
     if len(fw_files) == 0:
-        return ""
+        return None
 
     return str(sorted(fw_files, key=lambda x: fw_sort_key(x), reverse=True)[0].name)
 

--- a/goosebit/updater/misc.py
+++ b/goosebit/updater/misc.py
@@ -15,8 +15,21 @@ def sha1_hash_file(file_path: Path):
     return sha1_hash.hexdigest()
 
 
-def get_newest_fw() -> Optional[str]:
-    fw_files = [f for f in UPDATES_DIR.iterdir() if f.suffix == ".swu"]
+def get_newest_fw(hw_model: str, hw_revision: str) -> Optional[str]:
+    def filter_filename(filename, hw_model, hw_revision) -> bool:
+        image_data = filename.split("_")
+        if len(image_data) == 3:
+            return image_data[0] == hw_model
+        elif len(image_data) == 4:
+            return image_data[0] == hw_model and image_data[1] == hw_revision
+        else:
+            return False
+
+    fw_files = [
+        f
+        for f in UPDATES_DIR.iterdir()
+        if f.suffix == ".swu" and filter_filename(f.name, hw_model, hw_revision)
+    ]
     if len(fw_files) == 0:
         return None
 

--- a/goosebit/updater/updates.py
+++ b/goosebit/updater/updates.py
@@ -9,14 +9,13 @@ from goosebit.updater.misc import get_newest_fw, sha1_hash_file
 
 
 class FirmwareArtifact:
-    def __init__(self, file: str = None, dev_id: str = None):
+    def __init__(self, file: str = None, hw_model: str = None, hw_revision: str = None):
         if file == "latest":
-            self.file = get_newest_fw()
+            self.file = get_newest_fw(hw_model, hw_revision)
         elif file == "pinned":
             self.file = None
         else:
             self.file = file
-        self.dev_id = dev_id
 
     def __eq__(self, other):
         if isinstance(other, str):
@@ -46,7 +45,6 @@ class FirmwareArtifact:
                 return "_".join(image_data[1:])
 
             return "_".join(image_data[2:])
-
 
     @property
     def timestamp(self):
@@ -82,7 +80,6 @@ class FirmwareArtifact:
                                     request.url_for(
                                         self.dl_endpoint,
                                         tenant=tenant,
-                                        revision=revision,
                                         dev_id=dev_id,
                                         file=self.file,
                                     )

--- a/main.py
+++ b/main.py
@@ -2,7 +2,7 @@ import uvicorn
 
 from goosebit import app
 
-uvicorn_args = {"port": 8080}
+uvicorn_args = {"port": 80}
 
 if __name__ == "__main__":
     uvicorn.run(app, host="0.0.0.0", **uvicorn_args)

--- a/migrations/models/0_20240711084150_init.py
+++ b/migrations/models/0_20240711084150_init.py
@@ -1,0 +1,36 @@
+from tortoise import BaseDBAsyncClient
+
+
+async def upgrade(db: BaseDBAsyncClient) -> str:
+    return """
+        CREATE TABLE IF NOT EXISTS "device" (
+    "uuid" VARCHAR(255) NOT NULL  PRIMARY KEY,
+    "name" VARCHAR(255),
+    "fw_file" VARCHAR(255) NOT NULL  DEFAULT 'latest',
+    "fw_version" VARCHAR(255),
+    "last_state" VARCHAR(255),
+    "last_log" TEXT,
+    "last_seen" BIGINT,
+    "last_ip" VARCHAR(15),
+    "last_ipv6" VARCHAR(40)
+);
+CREATE TABLE IF NOT EXISTS "tag" (
+    "id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    "name" VARCHAR(255) NOT NULL
+);
+CREATE TABLE IF NOT EXISTS "aerich" (
+    "id" INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL,
+    "version" VARCHAR(255) NOT NULL,
+    "app" VARCHAR(100) NOT NULL,
+    "content" JSON NOT NULL
+);
+CREATE TABLE IF NOT EXISTS "device_tags" (
+    "device_id" VARCHAR(255) NOT NULL REFERENCES "device" ("uuid") ON DELETE CASCADE,
+    "tag_id" INT NOT NULL REFERENCES "tag" ("id") ON DELETE CASCADE
+);
+CREATE UNIQUE INDEX IF NOT EXISTS "uidx_device_tags_device__2ab77e" ON "device_tags" ("device_id", "tag_id");"""
+
+
+async def downgrade(db: BaseDBAsyncClient) -> str:
+    return """
+        """

--- a/migrations/models/1_20240712094019_update.py
+++ b/migrations/models/1_20240712094019_update.py
@@ -1,0 +1,13 @@
+from tortoise import BaseDBAsyncClient
+
+
+async def upgrade(db: BaseDBAsyncClient) -> str:
+    return """
+        ALTER TABLE "device" ADD "hw_revision" VARCHAR(255)   DEFAULT 'default';
+        ALTER TABLE "device" ADD "hw_model" VARCHAR(255)   DEFAULT 'default';"""
+
+
+async def downgrade(db: BaseDBAsyncClient) -> str:
+    return """
+        ALTER TABLE "device" DROP COLUMN "hw_revision";
+        ALTER TABLE "device" DROP COLUMN "hw_model";"""

--- a/migrations/models/2_20240712160819_default_value.py
+++ b/migrations/models/2_20240712160819_default_value.py
@@ -1,0 +1,17 @@
+from tortoise import BaseDBAsyncClient
+
+
+async def upgrade(db: BaseDBAsyncClient) -> str:
+    return """
+        ALTER TABLE "device" ADD "new_last_state" VARCHAR(255)   DEFAULT 'unknown';
+        UPDATE "device" SET "new_last_state" = COALESCE("last_state", 'unknown');
+        ALTER TABLE "device" DROP "last_state";
+        ALTER TABLE "device" RENAME COLUMN "new_last_state" TO "last_state";"""
+
+
+async def downgrade(db: BaseDBAsyncClient) -> str:
+    return """
+        ALTER TABLE "device" ADD "old_last_state" VARCHAR(255);
+        UPDATE "device" SET "old_last_state" = "last_state";
+        ALTER TABLE "device" DROP "last_state";
+        ALTER TABLE "device" RENAME COLUMN "old_last_state" TO "last_state";"""


### PR DESCRIPTION
Main goal was to introduce `hw_model` and `hw_revison` to support different device types. Values are reported by devices (or left at "default") and gooseBit then choses the latest _matching_ firmware image (if set to "latest").