### PR TITLE
Add install progress information

### DIFF
--- a/goosebit/api/devices.py
+++ b/goosebit/api/devices.py
@@ -35,6 +35,7 @@ async def devices_get_all() -> list[dict]:
             "fw_file": device.fw_file,
             "hw_model": device.hw_model,
             "hw_revision": device.hw_revision,
+            "download_percentage": device.download_percentage,
             "state": device.last_state,
             "force_update": manager.force_update,
             "last_ip": device.last_ip,

--- a/goosebit/api/devices.py
+++ b/goosebit/api/devices.py
@@ -35,7 +35,7 @@ async def devices_get_all() -> list[dict]:
             "fw_file": device.fw_file,
             "hw_model": device.hw_model,
             "hw_revision": device.hw_revision,
-            "download_percentage": device.download_percentage,
+            "progress": device.progress,
             "state": device.last_state,
             "force_update": manager.force_update,
             "last_ip": device.last_ip,

--- a/goosebit/models.py
+++ b/goosebit/models.py
@@ -14,7 +14,7 @@ class Device(Model):
     hw_model = fields.CharField(max_length=255, null=True, default="default")
     hw_revision = fields.CharField(max_length=255, null=True, default="default")
     last_state = fields.CharField(max_length=255, null=True, default="unknown")
-    download_percentage = fields.IntField(null=True)
+    progress = fields.IntField(null=True)
     last_log = fields.TextField(null=True)
     last_seen = fields.BigIntField(null=True)
     last_ip = fields.CharField(max_length=15, null=True)

--- a/goosebit/models.py
+++ b/goosebit/models.py
@@ -14,6 +14,7 @@ class Device(Model):
     hw_model = fields.CharField(max_length=255, null=True, default="default")
     hw_revision = fields.CharField(max_length=255, null=True, default="default")
     last_state = fields.CharField(max_length=255, null=True, default="unknown")
+    download_percentage = fields.IntField(null=True)
     last_log = fields.TextField(null=True)
     last_seen = fields.BigIntField(null=True)
     last_ip = fields.CharField(max_length=15, null=True)

--- a/goosebit/realtime/logs.py
+++ b/goosebit/realtime/logs.py
@@ -14,6 +14,7 @@ router = APIRouter(prefix="/logs")
 
 class RealtimeLogModel(BaseModel):
     log: str | None
+    progress: int | None
     clear: bool = False
 
 
@@ -29,7 +30,7 @@ async def device_logs(websocket: WebSocket, dev_id: str):
     manager = await get_update_manager(dev_id)
 
     async def callback(log_update):
-        data = RealtimeLogModel(log=log_update)
+        data = RealtimeLogModel(log=log_update, progress=manager.device.download_percentage)
         if log_update is None:
             data.clear = True
             data.log = ""

--- a/goosebit/realtime/logs.py
+++ b/goosebit/realtime/logs.py
@@ -30,7 +30,7 @@ async def device_logs(websocket: WebSocket, dev_id: str):
     manager = await get_update_manager(dev_id)
 
     async def callback(log_update):
-        data = RealtimeLogModel(log=log_update, progress=manager.device.download_percentage)
+        data = RealtimeLogModel(log=log_update, progress=manager.device.progress)
         if log_update is None:
             data.clear = True
             data.log = ""

--- a/goosebit/ui/static/js/devices.js
+++ b/goosebit/ui/static/js/devices.js
@@ -58,6 +58,16 @@ document.addEventListener("DOMContentLoaded", function() {
                 }
             },
             { data: 'fw_file' },
+            {
+                data: 'download_percentage',
+                render: function(data, type, row) {
+                    if ( type === 'display' || type === 'filter' ) {
+                        return (data || "❓") + "%";
+                    }
+                    return data;
+                }
+
+            },
             { data: 'last_ip' },
             {
                 data: 'last_seen',

--- a/goosebit/ui/static/js/devices.js
+++ b/goosebit/ui/static/js/devices.js
@@ -59,7 +59,7 @@ document.addEventListener("DOMContentLoaded", function() {
             },
             { data: 'fw_file' },
             {
-                data: 'download_percentage',
+                data: 'progress',
                 render: function(data, type, row) {
                     if ( type === 'display' || type === 'filter' ) {
                         return (data || "❓") + "%";

--- a/goosebit/ui/static/js/index.js
+++ b/goosebit/ui/static/js/index.js
@@ -40,6 +40,16 @@ document.addEventListener("DOMContentLoaded", function() {
             },
             { data: 'uuid' },
             { data: 'fw' },
+            {
+                data: 'download_percentage',
+                render: function(data, type, row) {
+                    if ( type === 'display' || type === 'filter' ) {
+                        return (data || "❓") + "%";
+                    }
+                    return data;
+                }
+
+            },
             { data: 'last_ip' },
             {
                 data: 'last_seen',

--- a/goosebit/ui/static/js/index.js
+++ b/goosebit/ui/static/js/index.js
@@ -41,7 +41,7 @@ document.addEventListener("DOMContentLoaded", function() {
             { data: 'uuid' },
             { data: 'fw' },
             {
-                data: 'download_percentage',
+                data: 'progress',
                 render: function(data, type, row) {
                     if ( type === 'display' || type === 'filter' ) {
                         return (data || "❓") + "%";

--- a/goosebit/ui/static/js/logs.js
+++ b/goosebit/ui/static/js/logs.js
@@ -9,6 +9,10 @@ document.addEventListener("DOMContentLoaded", function() {
             logElem.textContent = ""
         }
         logElem.textContent += res["log"];
+
+        const progressElem = document.getElementById('install-progress');
+        progressElem.style.width = `${res.progress}%`;
+        progressElem.innerHTML = `${res.progress}%`;
     });
 });
 

--- a/goosebit/ui/templates/devices.html
+++ b/goosebit/ui/templates/devices.html
@@ -31,6 +31,9 @@
                             Update File
                         </th>
                         <th>
+                            Download
+                        </th>
+                        <th>
                             Last IP
                         </th>
                         <th>

--- a/goosebit/ui/templates/devices.html
+++ b/goosebit/ui/templates/devices.html
@@ -31,7 +31,7 @@
                             Update File
                         </th>
                         <th>
-                            Download
+                            Progress
                         </th>
                         <th>
                             Last IP

--- a/goosebit/ui/templates/index.html
+++ b/goosebit/ui/templates/index.html
@@ -19,6 +19,9 @@
                             Firmware
                         </th>
                         <th>
+                            Download
+                        </th>
+                        <th>
                             Last IP
                         </th>
                         <th>

--- a/goosebit/ui/templates/index.html
+++ b/goosebit/ui/templates/index.html
@@ -19,7 +19,7 @@
                             Firmware
                         </th>
                         <th>
-                            Download
+                            Progress
                         </th>
                         <th>
                             Last IP

--- a/goosebit/ui/templates/logs.html
+++ b/goosebit/ui/templates/logs.html
@@ -7,6 +7,11 @@
                 <div class="card-header">
                     <h3>Logs - {{ device }}</h3>
                 </div>
+                <div class="card-header">
+                    <div class="progress m-2" role="progressbar" aria-label="Basic example" aria-valuenow="0" aria-valuemin="0" aria-valuemax="100">
+                        <div class="progress-bar progress-bar-striped progress-bar-animated" id="install-progress" style="width: 0%"></div>
+                    </div>
+                </div>
                 <div class="card-body">
                     <pre id="device-log"></pre>
                 </div>

--- a/goosebit/updater/controller/v1/routes.py
+++ b/goosebit/updater/controller/v1/routes.py
@@ -83,9 +83,7 @@ async def deployment_base(
         "deployment": {
             "download": update,
             "update": update,
-            "chunks": artifact.generate_chunk(
-                request, tenant=tenant, dev_id=dev_id
-            ),
+            "chunks": artifact.generate_chunk(request, tenant=tenant, dev_id=dev_id),
         },
     }
 

--- a/goosebit/updater/manager.py
+++ b/goosebit/updater/manager.py
@@ -178,7 +178,7 @@ class DeviceUpdateManager(UpdateManager):
         device = await self.get_device()
         matches = re.findall(r"Downloaded (\d+)%", log_data)
         if matches:
-            device.download_percentage = matches[-1]
+            device.progress = matches[-1]
         if device.last_log is None:
             device.last_log = ""
         if log_data.startswith("Installing Update Chunk Artifacts."):

--- a/goosebit/updater/manager.py
+++ b/goosebit/updater/manager.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import re
 from abc import ABC, abstractmethod
 from contextlib import asynccontextmanager
 from datetime import datetime
@@ -175,6 +176,9 @@ class DeviceUpdateManager(UpdateManager):
         if log_data is None:
             return
         device = await self.get_device()
+        matches = re.findall(r"Downloaded (\d+)%", log_data)
+        if matches:
+            device.download_percentage = matches[-1]
         if device.last_log is None:
             device.last_log = ""
         if log_data.startswith("Installing Update Chunk Artifacts."):
@@ -185,10 +189,12 @@ class DeviceUpdateManager(UpdateManager):
         if not log_data == "Skipped Update.":
             device.last_log += f"{log_data}\n"
             await self.publish_log(f"{log_data}\n")
+        await device.save()
 
     async def clear_log(self) -> None:
         device = await self.get_device()
         device.last_log = ""
+        await device.save()
         await self.publish_log(None)
 
 

--- a/goosebit/updater/updates.py
+++ b/goosebit/updater/updates.py
@@ -59,9 +59,7 @@ class FirmwareArtifact:
     def dl_endpoint(self):
         return "download_file"
 
-    def generate_chunk(
-        self, request: Request, tenant: str, dev_id: str
-    ) -> list:
+    def generate_chunk(self, request: Request, tenant: str, dev_id: str) -> list:
         if not self.file_exists():
             return []
         return [


### PR DESCRIPTION
- Add install progress to both device table and home table.
- Add progress bar to top of logs page.
- Add `progress` value to database.
