### PR TITLE
Add rollouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 
 ---
 
-A simplistic remote update server implementing hawkBit™'s [DDI API](https://eclipse.dev/hawkbit/apis/ddi_api/).
-
+A simplistic, opinionated remote update server implementing hawkBit™'s [DDI API](https://eclipse.dev/hawkbit/apis/ddi_api/).
 
 ## Setup
 
@@ -14,3 +13,39 @@ To set up, install the dependencies in `pyproject.toml` with `poetry install`.  
 
 The first time you start gooseBit, you should change the default username and password inside `settings.yaml`.
 The default login credentials for testing are `admin@goosebit.local`, `admin`.
+
+## Assumptions
+- [SWUpdate](https://swupdate.org) used on device side.
+
+## Current Feature Set
+
+### Firmware repository
+Uploading firmware images through frontend. Accepted file naming patterns are `model_revision_date_time.swu` /
+`model_date_time.swu`. Date and time is used to determine the most current version for a device with a give model
+and revision.
+
+### Automatic device registration
+First time a new device connects, its configuration data is requested. `hw_model` and `hw_revision` are captured from
+the configuration data (both fall back to `default` if not provided) which allows to distinguish different device
+types and their revisions.
+
+### Automatically update device to newest firmware
+Once a device is registered it will get the newest available firmware from the repository based on model and revision.
+
+### Manually update device to specific firmware
+Frontend allows to assign specific firmware to be rolled out.
+
+### Firmware rollout
+Rollouts allow a fine-grained assignment of firmwares to devices. The reported device model and revision is combined
+with the manually set feed and flavor values on a device to determine a matching rollout.
+
+The feed is meant to model either different environments (like: dev, qa, live) or update channels (like. candidate,
+fast, stable).
+
+The flavor can be used for different type of builds (like: debug, prod).
+
+### Pause updates
+Device can be pinned to its current firmware.
+
+### Realtime update logs
+While an update is running, the update logs are captured and visualized in the frontend.

--- a/goosebit/api/rollouts.py
+++ b/goosebit/api/rollouts.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import asyncio
+
+from fastapi import APIRouter, Security
+
+from goosebit.auth import validate_user_permissions
+from goosebit.models import Rollout
+from goosebit.permissions import Permissions
+
+router = APIRouter(prefix="/rollouts")
+
+
+@router.get(
+    "/all",
+    dependencies=[
+        Security(validate_user_permissions, scopes=[Permissions.ROLLOUT.READ])
+    ],
+)
+async def rollouts_get_all() -> list[dict]:
+    rollouts = await Rollout.all()
+
+    async def parse(rollout: Rollout) -> dict:
+        return {
+            "id": rollout.id,
+            "created_at": rollout.created_at,
+            "name": rollout.name,
+            "hw_model": rollout.hw_model,
+            "hw_revision": rollout.hw_revision,
+            "feed": rollout.feed,
+            "flavor": rollout.flavor,
+            "fw_file": rollout.fw_file,
+            "paused": rollout.paused,
+            "success_count": rollout.success_count,
+            "failure_count": rollout.failure_count,
+        }
+
+    return list(await asyncio.gather(*[parse(r) for r in rollouts]))

--- a/goosebit/api/routes.py
+++ b/goosebit/api/routes.py
@@ -1,6 +1,6 @@
 from fastapi import APIRouter, Depends
 
-from goosebit.api import devices, download, firmware
+from goosebit.api import devices, download, firmware, rollouts
 from goosebit.auth import authenticate_api_session
 
 router = APIRouter(
@@ -8,4 +8,5 @@ router = APIRouter(
 )
 router.include_router(firmware.router)
 router.include_router(devices.router)
+router.include_router(rollouts.router)
 router.include_router(download.router)

--- a/goosebit/models.py
+++ b/goosebit/models.py
@@ -13,6 +13,8 @@ class Device(Model):
     fw_version = fields.CharField(max_length=255, null=True)
     hw_model = fields.CharField(max_length=255, null=True, default="default")
     hw_revision = fields.CharField(max_length=255, null=True, default="default")
+    feed = fields.CharField(max_length=255, default="default")
+    flavor = fields.CharField(max_length=255, default="default")
     last_state = fields.CharField(max_length=255, null=True, default="unknown")
     last_log = fields.TextField(null=True)
     last_seen = fields.BigIntField(null=True)
@@ -21,3 +23,17 @@ class Device(Model):
     tags = fields.ManyToManyField(
         "models.Tag", related_name="devices", through="device_tags"
     )
+
+
+class Rollout(Model):
+    id = fields.IntField(pk=True)
+    created_at = fields.DatetimeField(auto_now_add=True)
+    name = fields.CharField(max_length=255, null=True)
+    hw_model = fields.CharField(max_length=255, default="default")
+    hw_revision = fields.CharField(max_length=255, default="default")
+    feed = fields.CharField(max_length=255, default="default")
+    flavor = fields.CharField(max_length=255, default="default")
+    fw_file = fields.CharField(max_length=255)
+    paused = fields.BooleanField(default=False)
+    success_count = fields.IntField(default=0)
+    failure_count = fields.IntField(default=0)

--- a/goosebit/permissions.py
+++ b/goosebit/permissions.py
@@ -22,6 +22,12 @@ class DevicePermissions(PermissionsBase):
     DELETE = "devices.delete"
 
 
+class RolloutPermissions(PermissionsBase):
+    READ = "rollouts.read"
+    WRITE = "rollouts.write"
+    DELETE = "rollouts.delete"
+
+
 class HomePermissions(PermissionsBase):
     READ = "home.read"
 
@@ -30,11 +36,12 @@ class Permissions:
     HOME = HomePermissions
     FIRMWARE = FirmwarePermissions
     DEVICE = DevicePermissions
+    ROLLOUT = RolloutPermissions
 
     @classmethod
     def full(cls):
         all_items = set()
-        for item in [cls.HOME, cls.FIRMWARE, cls.DEVICE]:
+        for item in [cls.HOME, cls.FIRMWARE, cls.DEVICE, cls.ROLLOUT]:
             all_items.update(item.full())
         return list(all_items)
 
@@ -46,9 +53,11 @@ class Permissions:
         if permission_type == "firmware":
             return FirmwarePermissions(permission)
         if permission_type == "devices":
-            return FirmwarePermissions(permission)
+            return DevicePermissions(permission)
+        if permission_type == "rollouts":
+            return RolloutPermissions(permission)
         if permission_type == "home":
-            return FirmwarePermissions(permission)
+            return HomePermissions(permission)
 
 
 ADMIN = Permissions.full()

--- a/goosebit/settings.py
+++ b/goosebit/settings.py
@@ -23,6 +23,7 @@ TENANT = config.get("tenant", "DEFAULT")
 
 POLL_TIME = config.get("poll_time_default", "00:01:00")
 POLL_TIME_UPDATING = config.get("poll_time_updating", "00:00:05")
+POLL_TIME_REGISTRATION = config.get("poll_time_updating", "00:00:10")
 
 DB_LOC = BASE_DIR.joinpath(config.get("db_location", "db.sqlite3"))
 DB_URI = f"sqlite:///{DB_LOC}"

--- a/goosebit/ui/routes.py
+++ b/goosebit/ui/routes.py
@@ -85,6 +85,18 @@ async def devices_ui(request: Request):
 
 
 @router.get(
+    "/rollouts",
+    dependencies=[
+        Security(validate_user_permissions, scopes=[Permissions.ROLLOUT.READ])
+    ],
+)
+async def rollouts_ui(request: Request):
+    return templates.TemplateResponse(
+        "rollouts.html", context={"request": request, "title": "Rollouts"}
+    )
+
+
+@router.get(
     "/logs/{dev_id}",
     dependencies=[
         Security(validate_user_permissions, scopes=[Permissions.DEVICE.READ])

--- a/goosebit/ui/static/js/devices.js
+++ b/goosebit/ui/static/js/devices.js
@@ -213,16 +213,19 @@ function updateFirmwareSelection() {
         selectElem = document.getElementById("device-selected-fw");
 
         optionElem = document.createElement("option");
+        optionElem.value = "none";
+        optionElem.textContent = "none";
+        selectElem.appendChild(optionElem);
+
+        optionElem = document.createElement("option");
         optionElem.value = "latest";
         optionElem.textContent = "latest";
-
         selectElem.appendChild(optionElem);
 
         data.forEach(item => {
             optionElem = document.createElement("option");
             optionElem.value = item["name"];
             optionElem.textContent = item["name"];
-
             selectElem.appendChild(optionElem);
         });
     })

--- a/goosebit/ui/static/js/rollouts.js
+++ b/goosebit/ui/static/js/rollouts.js
@@ -1,0 +1,56 @@
+document.addEventListener("DOMContentLoaded", function() {
+    var dataTable = new DataTable("#rollout-table", {
+        responsive: true,
+        paging: false,
+        scrollCollapse: true,
+        scroller: true,
+        scrollY: "65vh",
+        stateSave: true,
+        select: true,
+        rowId: "id",
+        ajax: {
+            url: "/api/rollouts/all",
+            dataSrc: "",
+        },
+        initComplete:function(){
+        },
+        columnDefs: [],
+        columns: [
+            { data: 'id' },
+            { data: 'created_at' },
+            { data: 'name' },
+            { data: 'hw_model' },
+            { data: 'hw_revision' },
+            { data: 'feed' },
+            { data: 'flavor' },
+            { data: 'fw_file' },
+            { data: 'paused',
+              render: function(data, type) {
+                    if ( type === 'display' || type === 'filter' ) {
+                        color = data ? "success" : "light"
+                        return `
+                        <div class="text-${color}">
+                            ●
+                        </div>
+                        `
+                    }
+                    return data;
+                }
+            },
+            { data: 'success_count' },
+            { data: 'failure_count' },
+        ],
+        layout: {
+            top1Start: {
+                buttons: [
+                ]
+            },
+            bottom1Start: {
+                buttons: [
+                ]
+            }
+        },
+    });
+
+    dataTable.ajax.reload();
+});

--- a/goosebit/ui/templates/nav.html
+++ b/goosebit/ui/templates/nav.html
@@ -50,7 +50,9 @@
                         {% if "devices.read" in request.user.permissions %}
                             <a class="nav-link{% if request.url.path.endswith('devices') %} active{% endif %}" href="/ui/devices">Devices</a>
                         {% endif %}
-
+                        {% if "rollouts.read" in request.user.permissions %}
+                            <a class="nav-link{% if request.url.path.endswith('rollouts') %} active{% endif %}" href="/ui/rollouts">Rollouts</a>
+                        {% endif %}
                     </div>
                     <div class="navbar-nav d-flex flex-fill justify-content-end">
                         <a class="nav-link" href="/logout">Logout<i class="bi bi-box-arrow-right ps-2"></i></a>

--- a/goosebit/ui/templates/rollouts.html
+++ b/goosebit/ui/templates/rollouts.html
@@ -1,0 +1,53 @@
+{% extends "nav.html" %}
+{% block content %}
+<div class="container-fluid">
+    <div class="row p-2 d-flex justify-content-center">
+        <div class="col">
+            <table id="rollout-table" class="table table-hover">
+                <thead>
+                    <tr>
+                        <th>
+                            Id
+                        </th>
+                        <th>
+                            Created
+                        </th>
+                        <th>
+                            Name
+                        </th>
+                        <th>
+                            Model
+                        </th>
+                        <th>
+                            Revision
+                        </th>
+                        <th>
+                            Feed
+                        </th>
+                        <th>
+                            Flavour
+                        </th>
+                        <th>
+                            Update File
+                        </th>
+                        <th>
+                            Paused
+                        </th>
+                        <th>
+                            Success Count
+                        </th>
+                        <th>
+                            Failure Count
+                        </th>
+                    </tr>
+                </thead>
+                <tbody id="rollouts-list">
+
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+
+<script src="{{ url_for('static', path='js/rollouts.js') }}"></script>
+{% endblock content %}

--- a/goosebit/updater/controller/v1/routes.py
+++ b/goosebit/updater/controller/v1/routes.py
@@ -3,6 +3,7 @@ import json
 from fastapi import APIRouter, Depends
 from fastapi.requests import Request
 
+from goosebit.settings import POLL_TIME_REGISTRATION
 from goosebit.updater.manager import UpdateManager, get_update_manager
 
 # v1 is hardware revision
@@ -20,7 +21,7 @@ async def polling(
 
     if updater.device.last_state == "unknown":
         # device registration
-        sleep = "00:00:10"  # ensure that device will check back soon after registration
+        sleep = POLL_TIME_REGISTRATION
         links["configData"] = {
             "href": str(
                 request.url_for(
@@ -83,9 +84,7 @@ async def deployment_base(
         "deployment": {
             "download": update,
             "update": update,
-            "chunks": artifact.generate_chunk(
-                request, tenant=tenant, dev_id=dev_id
-            ),
+            "chunks": artifact.generate_chunk(request, tenant=tenant, dev_id=dev_id),
         },
     }
 

--- a/goosebit/updater/manager.py
+++ b/goosebit/updater/manager.py
@@ -159,11 +159,11 @@ class DeviceUpdateManager(UpdateManager):
             self.poll_time = POLL_TIME
         else:
             mode = "forced"
-            self.poll_time = "00:00:05"
+            self.poll_time = POLL_TIME_UPDATING
 
         if self.force_update:
             mode = "forced"
-            self.poll_time = "00:00:05"
+            self.poll_time = POLL_TIME_UPDATING
 
         if mode == "forced" and self.update_complete:
             self.update_complete = False

--- a/goosebit/updater/misc.py
+++ b/goosebit/updater/misc.py
@@ -19,7 +19,7 @@ def get_newest_fw(hw_model: str, hw_revision: str) -> Optional[str]:
     def filter_filename(filename, hw_model, hw_revision) -> bool:
         image_data = filename.split("_")
         if len(image_data) == 3:
-            return image_data[0] == hw_model
+            return image_data[0] == hw_model and "default" == hw_revision
         elif len(image_data) == 4:
             return image_data[0] == hw_model and image_data[1] == hw_revision
         else:

--- a/goosebit/updater/updates.py
+++ b/goosebit/updater/updates.py
@@ -35,9 +35,8 @@ class FirmwareArtifact:
         return self.path.exists()
 
     @property
-    def name(self):
-        if not self.is_empty():
-            return self.file.split(".")[0]
+    def name(self) -> Optional[str]:
+        return self.file
 
     @property
     def version(self):

--- a/goosebit/updater/updates.py
+++ b/goosebit/updater/updates.py
@@ -14,6 +14,8 @@ class FirmwareArtifact:
             self.file = get_newest_fw(hw_model, hw_revision)
         elif file == "pinned":
             self.file = None
+        elif file == "none":
+            self.file = None
         else:
             self.file = file
 
@@ -59,9 +61,7 @@ class FirmwareArtifact:
     def dl_endpoint(self):
         return "download_file"
 
-    def generate_chunk(
-        self, request: Request, tenant: str, dev_id: str
-    ) -> list:
+    def generate_chunk(self, request: Request, tenant: str, dev_id: str) -> list:
         if not self.file_exists():
             return []
         return [


### PR DESCRIPTION
First version of a rollout feature. UI does not yet allow creating/editing rollouts - it just displays those captured directly inside the database. Will enhance this once the feature is conceptually ok.

What it does
- Introduces concept of feeds and flavours to segregate different rollout streams
- For devices with firmware "none" the most recent matching rollout is looked up. If it is not paused, then the referenced firmware gets installed

Limitations
- No reliable approach to match firmware update success/failure events to the originating rollout/firmware version 
- No abort mechanism implemented yet - key feature of rollout to stop as soon as "too many" issues got detected.