### PR TITLE
Add metrics and Prometheus support

### DIFF
--- a/goosebit/__init__.py
+++ b/goosebit/__init__.py
@@ -5,8 +5,9 @@ from fastapi import Depends, FastAPI
 from fastapi.requests import Request
 from fastapi.responses import RedirectResponse
 from fastapi.security import OAuth2PasswordRequestForm
+from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor as Instrumentor
 
-from goosebit import api, db, realtime, ui, updater
+from goosebit import api, db, realtime, telemetry, ui, updater
 from goosebit.auth import (
     authenticate_user,
     auto_redirect,
@@ -20,6 +21,7 @@ from goosebit.ui.templates import templates
 @asynccontextmanager
 async def lifespan(_: FastAPI):
     await db.init()
+    await telemetry.init()
     yield
     await db.close()
 
@@ -30,6 +32,7 @@ app.include_router(ui.router)
 app.include_router(api.router)
 app.include_router(realtime.router)
 app.mount("/static", static, name="static")
+Instrumentor.instrument_app(app)
 
 
 @app.middleware("http")
@@ -49,7 +52,9 @@ async def login_ui(request: Request):
 
 
 @app.post("/login", include_in_schema=False, dependencies=[Depends(authenticate_user)])
-async def login(request: Request, form_data: Annotated[OAuth2PasswordRequestForm, Depends()]):
+async def login(
+    request: Request, form_data: Annotated[OAuth2PasswordRequestForm, Depends()]
+):
     resp = RedirectResponse(request.url_for("ui_root"), status_code=302)
     resp.set_cookie(key="session_id", value=create_session(form_data.username))
     return resp

--- a/goosebit/telemetry/__init__.py
+++ b/goosebit/telemetry/__init__.py
@@ -1,0 +1,30 @@
+from opentelemetry import metrics
+from opentelemetry.sdk.metrics import MeterProvider
+from opentelemetry.sdk.resources import SERVICE_NAME, Resource
+
+from goosebit import settings
+from goosebit.models import Device
+
+from . import prometheus
+
+resource = Resource(attributes={SERVICE_NAME: "goosebit"})
+
+provider = MeterProvider(resource=resource, metric_readers=[prometheus.reader])
+metrics.set_meter_provider(provider)
+
+meter = metrics.get_meter("goosebit.meter")
+
+devices_count = meter.create_gauge(
+    "devices.count",
+    description="The number of connected devices",
+)
+
+users_count = meter.create_gauge(
+    "users.count",
+    description="The number of registered users",
+)
+
+
+async def init():
+    devices_count.set(len(await Device.all()))
+    users_count.set(len(settings.USERS))

--- a/goosebit/telemetry/prometheus.py
+++ b/goosebit/telemetry/prometheus.py
@@ -1,0 +1,12 @@
+from opentelemetry.exporter.prometheus import PrometheusMetricReader
+from prometheus_client import start_http_server
+
+from goosebit import settings
+
+PROMETHEUS_PORT = (
+    settings.config.get("metrics", {}).get("prometheus", {}).get("port", 9090)
+)
+
+# separate file to enable it as a feature later.
+reader = PrometheusMetricReader()
+start_http_server(port=PROMETHEUS_PORT, addr="0.0.0.0")

--- a/goosebit/updater/manager.py
+++ b/goosebit/updater/manager.py
@@ -9,6 +9,7 @@ from typing import Callable, Optional
 
 from goosebit.models import Device, Rollout
 from goosebit.settings import POLL_TIME, POLL_TIME_UPDATING
+from goosebit.telemetry import devices_count
 from goosebit.updates.artifacts import FirmwareArtifact
 
 
@@ -227,6 +228,7 @@ async def get_update_manager(dev_id: str) -> UpdateManager:
     global device_managers
     if device_managers.get(dev_id) is None:
         device_managers[dev_id] = DeviceUpdateManager(dev_id)
+    devices_count.set(len(await Device.all()))
     return device_managers[dev_id]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,9 @@ websockets = "^12.0"
 argon2-cffi = "^23.1.0"
 joserfc = "^1.0.0"
 semver = "^3.0.2"
+opentelemetry-distro = "^0.46b0"
+opentelemetry-instrumentation-fastapi = "^0.46b0"
+opentelemetry-exporter-prometheus = "^0.46b0"
 
 [tool.poetry.group.dev.dependencies]
 isort = "^5.13.2"

--- a/settings.yaml
+++ b/settings.yaml
@@ -9,6 +9,10 @@ tenant: DEFAULT
 #  - `semantic`: Update file should end with a semantic version (https://semver.org/)
 version_format: datetime
 
+metrics:
+  prometheus:
+    port: 9090
+
 users:
 - email: admin@goosebit.local
   password: admin


### PR DESCRIPTION
Adds some very basic metrics (registered users and device count), along with the default metrics provided by OpenTelemetry and its FastAPI integration.  We may want to look at making the different exporters into feature flags.

This should provide a very basic starting point to start adding better telemetry, along with spans and logging.