### PR TITLE
Immediate device updates & limit attributes to be updated

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -39,6 +39,10 @@ async def async_client(test_app):
     async with AsyncClient(
         transport=ASGITransport(app=test_app), base_url="http://test"
     ) as client:
+        login_data = {"username": "admin@goosebit.local", "password": "admin"}
+        response = await client.post("/login", data=login_data, follow_redirects=True)
+        assert response.status_code == 200
+
         yield client
 
 

--- a/conftest.py
+++ b/conftest.py
@@ -68,20 +68,6 @@ async def test_data(db):
             hardware=compatibility,
         )
 
-        device_latest = await Device.create(
-            uuid="device2",
-            last_state=UpdateStateEnum.REGISTERED,
-            update_mode=UpdateModeEnum.LATEST,
-            hardware=compatibility,
-        )
-
-        device_pinned = await Device.create(
-            uuid="device3",
-            last_state=UpdateStateEnum.REGISTERED,
-            update_mode=UpdateModeEnum.PINNED,
-            hardware=compatibility,
-        )
-
         temp_file_path = os.path.join(temp_dir, "firmware")
         with open(temp_file_path, "w") as temp_file:
             temp_file.write("Fake SWUpdate image")
@@ -115,8 +101,6 @@ async def test_data(db):
 
         yield dict(
             device_rollout=device_rollout,
-            device_latest=device_latest,
-            device_pinned=device_pinned,
             firmware_latest=firmware_latest,
             rollout_default=rollout_default,
         )

--- a/goosebit/__init__.py
+++ b/goosebit/__init__.py
@@ -48,7 +48,7 @@ def root_redirect(request: Request):
 
 @app.get("/login", dependencies=[Depends(auto_redirect)], include_in_schema=False)
 async def login_ui(request: Request):
-    return templates.TemplateResponse("login.html", context={"request": request})
+    return templates.TemplateResponse(request, "login.html")
 
 
 @app.post("/login", include_in_schema=False, dependencies=[Depends(authenticate_user)])

--- a/goosebit/api/devices.py
+++ b/goosebit/api/devices.py
@@ -1,7 +1,7 @@
 import asyncio
 import time
 
-from fastapi import APIRouter, HTTPException, Security
+from fastapi import APIRouter, Security
 from fastapi.requests import Request
 from pydantic import BaseModel
 
@@ -66,12 +66,6 @@ class UpdateDevicesModel(BaseModel):
     ],
 )
 async def devices_update(request: Request, config: UpdateDevicesModel) -> dict:
-    firmware = None
-    if config.firmware is not None:
-        firmware = await Firmware.get_or_none(id=config.firmware)
-        if firmware is None:
-            raise HTTPException(404)
-
     for uuid in config.devices:
         updater = await get_update_manager(uuid)
         if config.firmware is not None:
@@ -80,6 +74,7 @@ async def devices_update(request: Request, config: UpdateDevicesModel) -> dict:
             elif config.firmware == "latest":
                 await updater.update_update(UpdateModeEnum.LATEST, None)
             else:
+                firmware = await Firmware.get_or_none(id=config.firmware)
                 await updater.update_update(UpdateModeEnum.ASSIGNED, firmware)
         if config.pinned:
             await updater.update_update(UpdateModeEnum.PINNED, None)

--- a/goosebit/settings.py
+++ b/goosebit/settings.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import yaml
 from argon2 import PasswordHasher
+from joserfc.rfc7518.oct_key import OctKey
 
 from goosebit.permissions import Permissions
 
@@ -13,7 +14,7 @@ SWUPDATE_FILES_DIR = BASE_DIR.joinpath("swupdate")
 UPDATES_DIR = BASE_DIR.joinpath("updates")
 DB_MIGRATIONS_LOC = BASE_DIR.joinpath("migrations")
 
-SECRET = secrets.token_hex(16)
+SECRET = OctKey.import_key(secrets.token_hex(16))
 PWD_CXT = PasswordHasher()
 
 with open(BASE_DIR.joinpath("settings.yaml"), "r") as f:

--- a/goosebit/ui/routes.py
+++ b/goosebit/ui/routes.py
@@ -31,7 +31,7 @@ async def ui_root(request: Request):
 )
 async def firmware_ui(request: Request):
     return templates.TemplateResponse(
-        "firmware.html", context={"request": request, "title": "Firmware"}
+        request, "firmware.html", context={"title": "Firmware"}
     )
 
 
@@ -84,9 +84,7 @@ async def upload_update_remote(request: Request, url: str = Form(...)):
     dependencies=[Security(validate_user_permissions, scopes=[Permissions.HOME.READ])],
 )
 async def home_ui(request: Request):
-    return templates.TemplateResponse(
-        "index.html", context={"request": request, "title": "Home"}
-    )
+    return templates.TemplateResponse(request, "index.html", context={"title": "Home"})
 
 
 @router.get(
@@ -97,7 +95,7 @@ async def home_ui(request: Request):
 )
 async def devices_ui(request: Request):
     return templates.TemplateResponse(
-        "devices.html", context={"request": request, "title": "Devices"}
+        request, "devices.html", context={"title": "Devices"}
     )
 
 
@@ -109,7 +107,7 @@ async def devices_ui(request: Request):
 )
 async def rollouts_ui(request: Request):
     return templates.TemplateResponse(
-        "rollouts.html", context={"request": request, "title": "Rollouts"}
+        request, "rollouts.html", context={"title": "Rollouts"}
     )
 
 
@@ -121,5 +119,5 @@ async def rollouts_ui(request: Request):
 )
 async def logs_ui(request: Request, dev_id: str):
     return templates.TemplateResponse(
-        "logs.html", context={"request": request, "title": "Log", "device": dev_id}
+        request, "logs.html", context={"title": "Log", "device": dev_id}
     )

--- a/goosebit/updater/controller/v1/routes.py
+++ b/goosebit/updater/controller/v1/routes.py
@@ -174,5 +174,4 @@ async def deployment_feedback(
     except KeyError:
         logging.warning(f"No details to update update log, device={dev_id}")
 
-    await updater.save()
     return {"id": str(action_id)}

--- a/goosebit/updater/manager.py
+++ b/goosebit/updater/manager.py
@@ -281,17 +281,10 @@ async def get_update_manager(dev_id: str) -> UpdateManager:
     return device_managers[dev_id]
 
 
-def get_update_manager_sync(dev_id: str) -> UpdateManager:
-    global device_managers
-    if device_managers.get(dev_id) is None:
-        device_managers[dev_id] = DeviceUpdateManager(dev_id)
-    return device_managers[dev_id]
-
-
 async def delete_device(dev_id: str) -> None:
     global device_managers
     try:
-        updater = get_update_manager_sync(dev_id)
+        updater = await get_update_manager(dev_id)
         await (await updater.get_device()).delete()
         del device_managers[dev_id]
     except KeyError as e:

--- a/goosebit/updater/routes.py
+++ b/goosebit/updater/routes.py
@@ -18,9 +18,7 @@ async def verify_tenant(tenant: str):
 async def log_last_connection(request: Request, dev_id: str):
     host = request.client.host
     updater = get_update_manager_sync(dev_id)
-    await updater.update_last_ip(host)
-    await updater.update_last_seen(round(time.time()))
-    await updater.save()
+    await updater.update_last_connection(round(time.time()), host)
 
 
 router = APIRouter(

--- a/goosebit/updater/routes.py
+++ b/goosebit/updater/routes.py
@@ -6,7 +6,7 @@ from fastapi.requests import Request
 from goosebit.settings import TENANT
 
 from . import controller
-from .manager import get_update_manager_sync
+from .manager import get_update_manager
 
 
 async def verify_tenant(tenant: str):
@@ -17,7 +17,7 @@ async def verify_tenant(tenant: str):
 
 async def log_last_connection(request: Request, dev_id: str):
     host = request.client.host
-    updater = get_update_manager_sync(dev_id)
+    updater = await get_update_manager(dev_id)
     await updater.update_last_connection(round(time.time()), host)
 
 

--- a/tests/updater/controller/v1/test_routes.py
+++ b/tests/updater/controller/v1/test_routes.py
@@ -1,9 +1,35 @@
 import pytest
 
-from goosebit.models import Firmware, Hardware, UpdateStateEnum
+from goosebit.models import Firmware, Hardware
 from goosebit.updater.manager import get_update_manager
 
 UUID = "221326d9-7873-418e-960c-c074026a3b7c"
+
+
+async def _api_login(async_client):
+    login_data = {"username": "admin@goosebit.local", "password": "admin"}
+    response = await async_client.post("/login", data=login_data, follow_redirects=True)
+    assert response.status_code == 200
+
+
+async def _api_device_update(async_client, device, update_attribute, update_value):
+    response = await async_client.post(
+        f"/api/devices/update",
+        json={"devices": [f"{device.uuid}"], update_attribute: update_value},
+    )
+    assert response.status_code == 200
+
+
+async def _api_devices_get(async_client):
+    response = await async_client.get("/api/devices/all")
+    assert response.status_code == 200
+    return response.json()
+
+
+async def _api_rollouts_get(async_client):
+    response = await async_client.get("/api/rollouts/all")
+    assert response.status_code == 200
+    return response.json()
 
 
 async def _poll_first_time(async_client):
@@ -102,6 +128,10 @@ async def test_register_device(async_client, test_data):
 
     await _poll(async_client, UUID, None, False)
 
+    await _api_login(async_client)
+    devices = await _api_devices_get(async_client)
+    assert devices[0]["state"] == "Registered"
+
 
 @pytest.mark.asyncio
 async def test_rollout_full(async_client, test_data):
@@ -115,18 +145,20 @@ async def test_rollout_full(async_client, test_data):
 
     # confirm installation start (in reality: several of similar posts)
     await _feedback(async_client, device.uuid, firmware, "none", "proceeding")
-    await device.refresh_from_db()
-    assert device.last_state == UpdateStateEnum.RUNNING
+    await _api_login(async_client)
+    devices = await _api_devices_get(async_client)
+    assert devices[0]["state"] == "Running"
 
     # report finished installation
     await _feedback(async_client, device.uuid, firmware, "success", "closed")
-    await device.refresh_from_db()
-    assert device.last_state == UpdateStateEnum.FINISHED
-    assert device.fw_version == firmware.version
+    devices = await _api_devices_get(async_client)
+    assert devices[0]["state"] == "Finished"
+    assert devices[0]["fw"] == firmware.version
 
     await rollout.refresh_from_db()
-    assert rollout.success_count == 1
-    assert rollout.failure_count == 0
+    rollouts = await _api_rollouts_get(async_client)
+    assert rollouts[0]["success_count"] == 1
+    assert rollouts[0]["failure_count"] == 0
 
 
 @pytest.mark.asyncio
@@ -140,8 +172,9 @@ async def test_rollout_signalling_download_failure(async_client, test_data):
 
     # confirm installation start (in reality: several of similar posts)
     await _feedback(async_client, device.uuid, firmware, "none", "proceeding")
-    await device.refresh_from_db()
-    assert device.last_state == UpdateStateEnum.RUNNING
+    await _api_login(async_client)
+    devices = await _api_devices_get(async_client)
+    assert devices[0]["state"] == "Running"
 
     # HEAD /api/download/1 HTTP/1.1 (reason not clear)
     response = await async_client.head(firmware_url)
@@ -154,14 +187,17 @@ async def test_rollout_signalling_download_failure(async_client, test_data):
 
     # report failure
     await _feedback(async_client, device.uuid, firmware, "failure", "closed")
-    await device.refresh_from_db()
-    assert device.last_state == UpdateStateEnum.ERROR
+    devices = await _api_devices_get(async_client)
+    assert devices[0]["state"] == "Error"
 
 
 @pytest.mark.asyncio
 async def test_latest(async_client, test_data):
-    device = test_data["device_latest"]
+    device = test_data["device_rollout"]
     firmware = test_data["firmware_latest"]
+
+    await _api_login(async_client)
+    await _api_device_update(async_client, device, "firmware", "latest")
 
     deployment_base = await _poll(async_client, device.uuid, firmware)
 
@@ -169,19 +205,23 @@ async def test_latest(async_client, test_data):
 
     # confirm installation start (in reality: several of similar posts)
     await _feedback(async_client, device.uuid, firmware, "none", "proceeding")
-    await device.refresh_from_db()
-    assert device.last_state == UpdateStateEnum.RUNNING
+    await _api_login(async_client)
+    devices = await _api_devices_get(async_client)
+    assert devices[0]["state"] == "Running"
 
     # report finished installation
     await _feedback(async_client, device.uuid, firmware, "success", "closed")
-    await device.refresh_from_db()
-    assert device.last_state == UpdateStateEnum.FINISHED
-    assert device.fw_version == firmware.version
+    devices = await _api_devices_get(async_client)
+    assert devices[0]["state"] == "Finished"
+    assert devices[0]["fw"] == firmware.version
 
 
 @pytest.mark.asyncio
 async def test_latest_with_no_firmware_available(async_client, test_data):
-    device = test_data["device_latest"]
+    device = test_data["device_rollout"]
+
+    await _api_login(async_client)
+    await _api_device_update(async_client, device, "firmware", "latest")
 
     fake_hardware = await Hardware.create(model="does-not-exist", revision="default")
     device.hardware_id = fake_hardware.id
@@ -192,15 +232,22 @@ async def test_latest_with_no_firmware_available(async_client, test_data):
 
 @pytest.mark.asyncio
 async def test_pinned(async_client, test_data):
-    device = test_data["device_pinned"]
+    device = test_data["device_rollout"]
+
+    await _api_login(async_client)
+    await _api_device_update(async_client, device, "pinned", True)
 
     await _poll(async_client, device.uuid, None, False)
 
 
 @pytest.mark.asyncio
 async def test_up_to_date(async_client, test_data):
-    device = test_data["device_latest"]
+    device = test_data["device_rollout"]
     firmware = test_data["firmware_latest"]
+
+    await _api_login(async_client)
+    await _api_device_update(async_client, device, "firmware", "latest")
+
     manager = await get_update_manager(dev_id=device.uuid)
     await manager.update_fw_version(firmware.version)
 

--- a/tests/updater/controller/v1/test_routes.py
+++ b/tests/updater/controller/v1/test_routes.py
@@ -6,12 +6,6 @@ from goosebit.updater.manager import get_update_manager
 UUID = "221326d9-7873-418e-960c-c074026a3b7c"
 
 
-async def _api_login(async_client):
-    login_data = {"username": "admin@goosebit.local", "password": "admin"}
-    response = await async_client.post("/login", data=login_data, follow_redirects=True)
-    assert response.status_code == 200
-
-
 async def _api_device_update(async_client, device, update_attribute, update_value):
     response = await async_client.post(
         f"/api/devices/update",
@@ -128,7 +122,6 @@ async def test_register_device(async_client, test_data):
 
     await _poll(async_client, UUID, None, False)
 
-    await _api_login(async_client)
     devices = await _api_devices_get(async_client)
     assert devices[0]["state"] == "Registered"
 
@@ -145,7 +138,6 @@ async def test_rollout_full(async_client, test_data):
 
     # confirm installation start (in reality: several of similar posts)
     await _feedback(async_client, device.uuid, firmware, "none", "proceeding")
-    await _api_login(async_client)
     devices = await _api_devices_get(async_client)
     assert devices[0]["state"] == "Running"
 
@@ -172,7 +164,6 @@ async def test_rollout_signalling_download_failure(async_client, test_data):
 
     # confirm installation start (in reality: several of similar posts)
     await _feedback(async_client, device.uuid, firmware, "none", "proceeding")
-    await _api_login(async_client)
     devices = await _api_devices_get(async_client)
     assert devices[0]["state"] == "Running"
 
@@ -196,7 +187,6 @@ async def test_latest(async_client, test_data):
     device = test_data["device_rollout"]
     firmware = test_data["firmware_latest"]
 
-    await _api_login(async_client)
     await _api_device_update(async_client, device, "firmware", "latest")
 
     deployment_base = await _poll(async_client, device.uuid, firmware)
@@ -205,7 +195,6 @@ async def test_latest(async_client, test_data):
 
     # confirm installation start (in reality: several of similar posts)
     await _feedback(async_client, device.uuid, firmware, "none", "proceeding")
-    await _api_login(async_client)
     devices = await _api_devices_get(async_client)
     assert devices[0]["state"] == "Running"
 
@@ -220,7 +209,6 @@ async def test_latest(async_client, test_data):
 async def test_latest_with_no_firmware_available(async_client, test_data):
     device = test_data["device_rollout"]
 
-    await _api_login(async_client)
     await _api_device_update(async_client, device, "firmware", "latest")
 
     fake_hardware = await Hardware.create(model="does-not-exist", revision="default")
@@ -234,7 +222,6 @@ async def test_latest_with_no_firmware_available(async_client, test_data):
 async def test_pinned(async_client, test_data):
     device = test_data["device_rollout"]
 
-    await _api_login(async_client)
     await _api_device_update(async_client, device, "pinned", True)
 
     await _poll(async_client, device.uuid, None, False)
@@ -245,7 +232,6 @@ async def test_up_to_date(async_client, test_data):
     device = test_data["device_rollout"]
     firmware = test_data["firmware_latest"]
 
-    await _api_login(async_client)
     await _api_device_update(async_client, device, "firmware", "latest")
 
     manager = await get_update_manager(dev_id=device.uuid)


### PR DESCRIPTION
I was investigating the issue, that sometimes an assigned firmware got reset. It showed to be a combination of active UI and device polling. The Tortoise ORM logs were not that helpful as device updates always updated all attributes.

Refactored the code that it explicitly lists what should be updated - and does so immediately after modifying the device state. This either fixed the above issue or at least will help to more easily track it in the future.