### PR TITLE
tests: move cache disable to `conftest.py`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
     hooks:
       - id: pytest
         name: pytest
-        entry: env AIOCACHE_DISABLE=1 poetry run pytest tests
+        entry: env poetry run pytest tests
         language: system
         types: [python]
         pass_filenames: false

--- a/conftest.py
+++ b/conftest.py
@@ -14,6 +14,9 @@ from goosebit.models import UpdateModeEnum, UpdateStateEnum
 # Configure logging
 logging.basicConfig(level=logging.WARN)
 
+# disable caching
+os.environ["AIOCACHE_DISABLE"] = "1"
+
 TORTOISE_CONF = {
     "connections": {"default": "sqlite://:memory:"},
     "apps": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,9 +19,9 @@ argon2-cffi = "^23.1.0"
 joserfc = "^1.0.0"
 semver = "^3.0.2"
 libconf = "^2.0.1"
-opentelemetry-distro = "^0.46b0"
-opentelemetry-instrumentation-fastapi = "^0.46b0"
-opentelemetry-exporter-prometheus = "^0.46b0"
+opentelemetry-distro = "^0.47b0"
+opentelemetry-instrumentation-fastapi = "^0.47b0"
+opentelemetry-exporter-prometheus = "^0.47b0"
 aiocache = "^0.12.2"
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
Move the `AIOCACHE_DISABLE` environment variable to be set in `conftest.py`, which should ensure tests pass even when run manually.

Also updates open telemetry version to latest.