### PR TITLE
Change indentation in YAML files to 2 spaces

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,24 +1,24 @@
 name: PyPI
 
 on:
-    push:
-        tags:
-            - "v*.*.*"
-        paths-ignore:
-            - "**.md"
-            - "docs/**"
-            - "docsrc/**"
+  push:
+    tags:
+      - "v*.*.*"
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
+      - "docsrc/**"
 
 jobs:
-    build:
-        runs-on: ubuntu-latest
-        steps:
-            - uses: actions/checkout@v4.1.7
-            - name: Publish GH release
-              uses: softprops/action-gh-release@v2.0.6
-              with:
-                  generate_release_notes: true
-            - name: Build using poetry and publish to PyPi
-              uses: JRubics/poetry-publish@v2.0
-              with:
-                  pypi_token: ${{ secrets.PYPI_API_KEY }}
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.1.7
+      - name: Publish GH release
+        uses: softprops/action-gh-release@v2.0.6
+        with:
+          generate_release_notes: true
+      - name: Build using poetry and publish to PyPi
+        uses: JRubics/poetry-publish@v2.0
+        with:
+          pypi_token: ${{ secrets.PYPI_API_KEY }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,40 +1,40 @@
 repos:
-    - repo: https://github.com/pre-commit/pre-commit-hooks
-      rev: v4.6.0
-      hooks:
-          - id: trailing-whitespace
-          - id: check-yaml
-          - id: check-added-large-files
-    - repo: https://github.com/psf/black
-      rev: 24.4.2
-      hooks:
-          - id: black
-    - repo: https://github.com/pycqa/isort
-      rev: 5.13.2
-      hooks:
-          - id: isort
-            name: isort (python)
-    - repo: local
-      hooks:
-          - id: pytest
-            name: pytest
-            entry: env poetry run pytest tests
-            language: system
-            types: [python]
-            pass_filenames: false
-            always_run: true
-    - repo: https://github.com/pycqa/flake8
-      rev: 7.1.0 # You can specify the version of Flake8 you want to use
-      hooks:
-          - id: flake8
-            additional_dependencies: []
-    - repo: https://github.com/biomejs/pre-commit
-      rev: "v0.4.0"
-      hooks:
-          - id: biome-check
-            additional_dependencies: ["@biomejs/biome@1.8.3"]
-    - repo: https://github.com/rbubley/mirrors-prettier
-      rev: "v3.3.3"
-      hooks:
-          - id: prettier
-            files: \.(html|md|yml|yaml)$
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: trailing-whitespace
+      - id: check-yaml
+      - id: check-added-large-files
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
+  - repo: https://github.com/pycqa/isort
+    rev: 5.13.2
+    hooks:
+      - id: isort
+        name: isort (python)
+  - repo: local
+    hooks:
+      - id: pytest
+        name: pytest
+        entry: env poetry run pytest tests
+        language: system
+        types: [python]
+        pass_filenames: false
+        always_run: true
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.1.0 # You can specify the version of Flake8 you want to use
+    hooks:
+      - id: flake8
+        additional_dependencies: []
+  - repo: https://github.com/biomejs/pre-commit
+    rev: "v0.4.0"
+    hooks:
+      - id: biome-check
+        additional_dependencies: ["@biomejs/biome@1.8.3"]
+  - repo: https://github.com/rbubley/mirrors-prettier
+    rev: "v3.3.3"
+    hooks:
+      - id: prettier
+        files: \.(html|md|yml|yaml)$

--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -1,2 +1,8 @@
 useTabs: false
 tabWidth: 4
+overrides:
+  - files:
+      - "**/*.yaml"
+      - "**/*.yml"
+    options:
+      tabWidth: 2

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -3,16 +3,16 @@ version: 2
 
 # Set the version of Python and other tools you might need
 build:
-    os: ubuntu-20.04
-    tools: { python: "3.11" }
-    jobs:
-        pre_create_environment:
-            - asdf plugin add poetry
-            - asdf install poetry latest
-            - asdf global poetry latest
-            - poetry config virtualenvs.create false
-        post_install:
-            - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install --only docs
+  os: ubuntu-20.04
+  tools: { python: "3.11" }
+  jobs:
+    pre_create_environment:
+      - asdf plugin add poetry
+      - asdf install poetry latest
+      - asdf global poetry latest
+      - poetry config virtualenvs.create false
+    post_install:
+      - VIRTUAL_ENV=$READTHEDOCS_VIRTUALENV_PATH poetry install --only docs
 
 mkdocs:
-    configuration: mkdocs.yml
+  configuration: mkdocs.yml

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,6 +2,6 @@ repo_url: https://github.com/UpstreamDataInc/goosebit
 repo_name: gooseBit
 site_name: gooseBit
 theme:
-    name: material
-    logo: img/goosebit-logo.svg
-    favicon: img/goosebit-logo.svg
+  name: material
+  logo: img/goosebit-logo.svg
+  favicon: img/goosebit-logo.svg

--- a/settings.yaml
+++ b/settings.yaml
@@ -16,44 +16,44 @@ poll_time_updating: 00:00:05
 # "rollout.read", "rollout.write", "rollout.delete"
 # "home.read"
 users:
-    - email: admin@goosebit.local
-      password: admin
-      permissions:
-          - "*"
-    - email: ops@goosebit.local
-      password: ops
-      permissions:
-          - "home.read"
+  - email: admin@goosebit.local
+    password: admin
+    permissions:
+      - "*"
+  - email: ops@goosebit.local
+    password: ops
+    permissions:
+      - "home.read"
 
 ## Internal settings that usually don't need to be modified
 poll_time_registration: 00:00:10
 tenant: DEFAULT
 metrics:
-    prometheus:
-        port: 9090
+  prometheus:
+    port: 9090
 logging:
-    version: 1
-    formatters:
-        simple:
-            format: "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
-    handlers:
-        console:
-            class: logging.StreamHandler
-            formatter: simple
-            level: DEBUG
-    loggers:
-        tortoise:
-            handlers: [console]
-            level: WARNING
-            propagate: yes
-        aiosqlite:
-            handlers: [console]
-            level: WARNING
-            propagate: yes
-        multipart:
-            handlers: [console]
-            level: INFO
-            propagate: yes
-    root:
-        level: INFO
-        handlers: [console]
+  version: 1
+  formatters:
+    simple:
+      format: "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+  handlers:
+    console:
+      class: logging.StreamHandler
+      formatter: simple
+      level: DEBUG
+  loggers:
+    tortoise:
+      handlers: [console]
+      level: WARNING
+      propagate: yes
+    aiosqlite:
+      handlers: [console]
+      level: WARNING
+      propagate: yes
+    multipart:
+      handlers: [console]
+      level: INFO
+      propagate: yes
+  root:
+    level: INFO
+    handlers: [console]


### PR DESCRIPTION
Pretty much all YAML out there is indented with 2 spaces. This makes
copying & pasting from the internet easier.

Command used:

    pre-commit run --all-files