### PR TITLE
Add PostgreSQL database support

### DIFF
--- a/goosebit/settings.py
+++ b/goosebit/settings.py
@@ -28,8 +28,7 @@ POLL_TIME = config.get("poll_time_default", "00:01:00")
 POLL_TIME_UPDATING = config.get("poll_time_updating", "00:00:05")
 POLL_TIME_REGISTRATION = config.get("poll_time_registration", "00:00:10")
 
-DB_LOC = BASE_DIR.joinpath(config.get("db_location", "db.sqlite3"))
-DB_URI = f"sqlite:///{DB_LOC}"
+DB_URI = config.get("db_uri", f"sqlite:///{BASE_DIR.joinpath('db.sqlite3')}")
 
 
 @dataclass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,11 @@ opentelemetry-exporter-prometheus = "^0.47b0"
 aiocache = "^0.12.2"
 httpx = "^0.27.0"
 
+asyncpg = { version = "^0.29.0", optional = true }
+
+[tool.poetry.extras]
+postgresql = ["asyncpg"]
+
 [tool.poetry.group.dev.dependencies]
 isort = "^5.13.2"
 black = "^24.2.0"

--- a/settings.yaml
+++ b/settings.yaml
@@ -1,7 +1,7 @@
 ## Settings to adjust for each installation
 
-# Database to be used
-db_location: db.sqlite3
+# Database to be used, default:
+# db_uri: sqlite:///<project root>/db.sqlite3
 
 # Frequency that devices should check for available updates.
 poll_time_default: 00:01:00


### PR DESCRIPTION
The dependencies can be installed with

    poetry install --extras postgresql

or

    pip install goosebit[postgresql]

respectively.

Closes #54