### PR TITLE
Make artifact storage location configurable

### DIFF
--- a/goosebit/settings.py
+++ b/goosebit/settings.py
@@ -9,7 +9,6 @@ from joserfc.jwk import OctKey
 from goosebit.permissions import Permissions
 
 BASE_DIR = Path(__file__).resolve().parent.parent
-ARTIFACTS_DIR = BASE_DIR.joinpath("artifacts")
 DB_MIGRATIONS_LOC = BASE_DIR.joinpath("migrations")
 
 SECRET = OctKey.import_key(secrets.token_hex(16))
@@ -17,6 +16,8 @@ PWD_CXT = PasswordHasher()
 
 with open(BASE_DIR.joinpath("settings.yaml"), "r") as f:
     config = yaml.safe_load(f.read())
+
+ARTIFACTS_DIR = Path(config.get("artifacts_dir", BASE_DIR.joinpath("artifacts")))
 
 LOGGING = config.get("logging", {})
 

--- a/settings.yaml
+++ b/settings.yaml
@@ -3,6 +3,9 @@
 # Database to be used, default:
 # db_uri: sqlite:///<project root>/db.sqlite3
 
+# Path to the directory containing artifact files, default:
+# artifacts_dir: /<project root>/artifacts
+
 # Frequency that devices should check for available updates.
 poll_time_default: 00:01:00
 


### PR DESCRIPTION
This is done by setting `artifacts_dir` in your settings to an absolute path to a directory.

Also, use `NamedTemporaryFile` in `parse_remote`. Besides fixing an obvious concurrency bug, this removes the need for a local artifacts directory when only external files are used.
