### PR TITLE
Add support for configuration through env vars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,3 +167,6 @@ cython_debug/
 /db.sqlite3*
 /migrations
 /poetry.lock
+
+# dynaconf secret files
+.secrets.*

--- a/goosebit/settings.py
+++ b/goosebit/settings.py
@@ -2,8 +2,8 @@ import secrets
 from dataclasses import dataclass
 from pathlib import Path
 
-import yaml
 from argon2 import PasswordHasher
+from dynaconf import Dynaconf
 from joserfc.jwk import OctKey
 
 from goosebit.permissions import Permissions
@@ -14,8 +14,10 @@ DB_MIGRATIONS_LOC = BASE_DIR.joinpath("migrations")
 SECRET = OctKey.import_key(secrets.token_hex(16))
 PWD_CXT = PasswordHasher()
 
-with open(BASE_DIR.joinpath("settings.yaml"), "r") as f:
-    config = yaml.safe_load(f.read())
+config = Dynaconf(
+    envvar_prefix="GOOSEBIT",
+    settings_files=[BASE_DIR.joinpath("settings.yaml"), BASE_DIR.joinpath(".secrets.yaml")],
+)
 
 ARTIFACTS_DIR = Path(config.get("artifacts_dir", BASE_DIR.joinpath("artifacts")))
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ opentelemetry-instrumentation-fastapi = "^0.47b0"
 opentelemetry-exporter-prometheus = "^0.47b0"
 aiocache = "^0.12.2"
 httpx = "^0.27.0"
+dynaconf = "^3.2.6"
 
 asyncpg = { version = "^0.29.0", optional = true }
 


### PR DESCRIPTION
In addition to the key-value pairs in settings.yaml, the application can now be configured through corresponding `GOOSEBIT_*` environment variables. E.g. to use PostgreSQL, set:

    GOOSEBIT_DB_URI=postgres://db_user:db_pw@postgres:5432/goosebit

The users are configured as follows:

    GOOSEBIT_USERS='[{email="foo@b.ar", password="42", permissions="*"}]'

The environment variables have precedence over the configuration file.

For more information, read: https://www.dynaconf.com/envvars/