### PR TITLE
Fix software deletion from UI

### DIFF
--- a/goosebit/api/v1/software/requests.py
+++ b/goosebit/api/v1/software/requests.py
@@ -1,5 +1,5 @@
-from pydantic import BaseModel
+from pydantic import RootModel
 
 
-class SoftwareDeleteRequest(BaseModel):
-    files: list[int]
+class SoftwareDeleteRequest(RootModel[list[int]]):
+    pass

--- a/goosebit/api/v1/software/routes.py
+++ b/goosebit/api/v1/software/routes.py
@@ -26,7 +26,7 @@ async def software_get(_: Request) -> SoftwareResponse:
 )
 async def software_delete(_: Request, config: SoftwareDeleteRequest) -> StatusResponse:
     success = False
-    for f_id in config.files:
+    for f_id in config.root:
         software = await Software.get_or_none(id=f_id)
 
         if software is None:


### PR DESCRIPTION
UI sends array of IDs as the payload, but backend expected object with files property. Files is not a good naming, so adjusted backend.

UI however should always call the BFF, so some more work required. Not creating a test case for this issue before this bigger refactoring.

Fixes #89 