### PR TITLE
Move port to config.

### DIFF
--- a/goosebit/settings/schema.py
+++ b/goosebit/settings/schema.py
@@ -43,6 +43,8 @@ class MetricsSettings(BaseModel):
 class GooseBitSettings(BaseSettings):
     model_config = SettingsConfigDict(env_prefix="GOOSEBIT_")
 
+    port: int = 60053  # GOOSE
+
     artifacts_dir: Path = BASE_DIR.joinpath("artifacts")
 
     poll_time_default: str = "00:01:00"

--- a/main.py
+++ b/main.py
@@ -7,7 +7,6 @@ from goosebit.settings import config
 
 logging.config.dictConfig(config.logging)
 
-uvicorn_args = {"port": 80}
 
 if __name__ == "__main__":
-    uvicorn.run(app, host="0.0.0.0", **uvicorn_args)
+    uvicorn.run(app, host="0.0.0.0", port=config.port)

--- a/settings.yaml
+++ b/settings.yaml
@@ -1,5 +1,8 @@
 ## Settings to adjust for each installation
 
+# Port to host the server on, default:
+# port: 60053 # GOOSE ;)
+
 # Database to be used, default:
 # db_uri: sqlite:///<project root>/db.sqlite3
 


### PR DESCRIPTION
Server port can now be configured in `settings.yaml` with the `port` value, or using env with `GOOSEBIT_PORT` (case insensitive).