### PR TITLE
Fix gh-pages failed deploy

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -36,4 +36,4 @@ jobs:
         run: poetry install --no-root --with docs
 
       - name: Deploy website
-        run: poetry run mkdocs gh-deploy --theme material
+        run: poetry run mkdocs gh-deploy --theme material --force --no-history


### PR DESCRIPTION
Use `--no-history` and `--force` for `gh-deploy` args.

Closes #100 