### PR TITLE
Fix Docker CI workflow

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -17,15 +17,12 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set GOOSEBIT_VERSION env var
         run: |
-          if [ $GITHUB_REF_TYPE = tag ]; then
-            tag=$GITHUB_REF_NAME
-          else
-            echo "This job is only supposed to be run for Git tags"
-            exit 1
-          fi
+          tag=$(git describe --tags --abbrev=0)
           echo "GOOSEBIT_VERSION=${tag#v}" >> $GITHUB_ENV
 
       - name: Log in to Docker Hub


### PR DESCRIPTION
As we are triggered by the `PyPI` workflow and not directly by the push of the Git tag, extracting the version from `GITHUB_REF_NAME` won't work. Calling `git describe` instead also allows the workflow to be run manually, which makes things easier in general.

Fixes: #118