### PR TITLE
Support local files with matching filenames

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,18 @@ A simplistic, opinionated remote update server implementing hawkBit™'s [DDI AP
 ### Installation
 
 1. Install dependencies using [Poetry](https://python-poetry.org/):
+
     ```bash
     poetry install
     ```
-2. Launch gooseBit:
+
+2. Create the database:
+
+    ```bash
+    poetry run aerich upgrade
+    ```
+
+3. Launch gooseBit:
     ```bash
     python main.py
     ```

--- a/goosebit/__init__.py
+++ b/goosebit/__init__.py
@@ -1,5 +1,6 @@
 import importlib.metadata
 from contextlib import asynccontextmanager
+from logging import getLogger
 from typing import Annotated
 
 from fastapi import Depends, FastAPI
@@ -16,12 +17,17 @@ from goosebit.ui.nav import nav
 from goosebit.ui.static import static
 from goosebit.ui.templates import templates
 
+logger = getLogger(__name__)
+
 
 @asynccontextmanager
 async def lifespan(_: FastAPI):
-    await db.init()
+    db_ready = await db.init()
+    if not db_ready:
+        logger.exception("DB does not exist, try running `poetry run aerich upgrade`.")
     await metrics.init()
-    yield
+    if db_ready:
+        yield
     await db.close()
 
 

--- a/goosebit/db/__init__.py
+++ b/goosebit/db/__init__.py
@@ -1,11 +1,21 @@
+from logging import getLogger
+
 from tortoise import Tortoise
+from tortoise.exceptions import OperationalError
 
 from goosebit.db.config import TORTOISE_CONF
+from goosebit.db.models import Device
+
+logger = getLogger(__name__)
 
 
-async def init():
+async def init() -> bool:
     await Tortoise.init(config=TORTOISE_CONF)
-    await Tortoise.generate_schemas()
+    try:
+        await Device.first()
+    except OperationalError:
+        return False
+    return True
 
 
 async def close():

--- a/goosebit/db/__init__.py
+++ b/goosebit/db/__init__.py
@@ -5,6 +5,7 @@ from goosebit.db.config import TORTOISE_CONF
 
 async def init():
     await Tortoise.init(config=TORTOISE_CONF)
+    await Tortoise.generate_schemas()
 
 
 async def close():


### PR DESCRIPTION
Adds support for local files with matching filenames but different hashes.  This is done by moving the path of the files to `<artifact_dir>/<file_hash>/<filename>`.  Files with matching versions and compatibility will still collide and raise an error to the user.

Fixes: #104