### PR TITLE
Migrate file operations to async

### DIFF
--- a/goosebit/api/v1/software/routes.py
+++ b/goosebit/api/v1/software/routes.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import aiofiles
+from aiofiles import os
 from fastapi import APIRouter, File, Form, HTTPException, Security, UploadFile
 from fastapi.requests import Request
 
@@ -41,12 +42,14 @@ async def software_delete(_: Request, delete_req: SoftwareDeleteRequest) -> Stat
             raise HTTPException(409, "Software is referenced by rollout")
 
         if software.local:
-            path = software.path
-            if path.exists():
-                path.unlink()
+            try:
+                await os.unlink(software.path)
+            except OSError:
+                pass
 
         await software.delete()
         success = True
+
     return StatusResponse(success=success)
 
 

--- a/goosebit/api/v1/software/routes.py
+++ b/goosebit/api/v1/software/routes.py
@@ -44,6 +44,7 @@ async def software_delete(_: Request, delete_req: SoftwareDeleteRequest) -> Stat
         if software.local:
             try:
                 await os.unlink(software.path)
+                await os.rmdir(software.path.parent)
             except OSError:
                 pass
 


### PR DESCRIPTION
More for consistency than for improved performance (as aiofiles also uses threads to execute synchronous functions like fastapi would).

Also fixes an issue deleting software: containing folder was not removed.

Fixes #124 