### PR TITLE
Use `model_validate` built into pydantic to parse DB models

### DIFF
--- a/goosebit/api/v1/devices/device/routes.py
+++ b/goosebit/api/v1/devices/device/routes.py
@@ -18,7 +18,8 @@ async def device_get(_: Request, updater: UpdateManager = Depends(get_update_man
     device = await updater.get_device()
     if device is None:
         raise HTTPException(404)
-    return await DeviceResponse.convert(device)
+    await device.fetch_related("assigned_software", "hardware")
+    return DeviceResponse.model_validate(device)
 
 
 @router.get(

--- a/goosebit/api/v1/devices/responses.py
+++ b/goosebit/api/v1/devices/responses.py
@@ -1,16 +1,9 @@
 from __future__ import annotations
 
-import asyncio
-
 from pydantic import BaseModel
 
-from goosebit.db.models import Device
 from goosebit.schema.devices import DeviceSchema
 
 
 class DevicesResponse(BaseModel):
     devices: list[DeviceSchema]
-
-    @classmethod
-    async def convert(cls, devices: list[Device]):
-        return cls(devices=await asyncio.gather(*[DeviceSchema.convert(d) for d in devices]))

--- a/goosebit/api/v1/devices/routes.py
+++ b/goosebit/api/v1/devices/routes.py
@@ -20,7 +20,8 @@ router = APIRouter(prefix="/devices", tags=["devices"])
     dependencies=[Security(validate_user_permissions, scopes=["home.read"])],
 )
 async def devices_get(_: Request) -> DevicesResponse:
-    return await DevicesResponse.convert(await Device.all().prefetch_related("assigned_software", "hardware"))
+    devices = await Device.all().prefetch_related("assigned_software", "hardware")
+    return DevicesResponse(devices=devices)
 
 
 @router.delete(

--- a/goosebit/api/v1/rollouts/responses.py
+++ b/goosebit/api/v1/rollouts/responses.py
@@ -1,19 +1,14 @@
-import asyncio
+from __future__ import annotations
 
 from pydantic import BaseModel
 
 from goosebit.api.responses import StatusResponse
-from goosebit.db.models import Rollout
 from goosebit.schema.rollouts import RolloutSchema
 
 
 class RolloutsPutResponse(StatusResponse):
-    id: int
+    id: int | None = None
 
 
 class RolloutsResponse(BaseModel):
     rollouts: list[RolloutSchema]
-
-    @classmethod
-    async def convert(cls, devices: list[Rollout]):
-        return cls(rollouts=await asyncio.gather(*[RolloutSchema.convert(d) for d in devices]))

--- a/goosebit/api/v1/rollouts/routes.py
+++ b/goosebit/api/v1/rollouts/routes.py
@@ -1,9 +1,9 @@
-from fastapi import APIRouter, Security
+from fastapi import APIRouter, HTTPException, Security
 from fastapi.requests import Request
 
 from goosebit.api.responses import StatusResponse
 from goosebit.auth import validate_user_permissions
-from goosebit.db.models import Rollout
+from goosebit.db.models import Rollout, Software
 
 from .requests import RolloutsDeleteRequest, RolloutsPatchRequest, RolloutsPutRequest
 from .responses import RolloutsPutResponse, RolloutsResponse
@@ -24,6 +24,9 @@ async def rollouts_get(_: Request) -> RolloutsResponse:
     dependencies=[Security(validate_user_permissions, scopes=["rollout.write"])],
 )
 async def rollouts_put(_: Request, rollout: RolloutsPutRequest) -> RolloutsPutResponse:
+    software = await Software.filter(id=rollout.software_id)
+    if len(software) == 0:
+        raise HTTPException(404, f"No software with ID {rollout.software_id} found")
     rollout = await Rollout.create(
         name=rollout.name,
         feed=rollout.feed,

--- a/goosebit/api/v1/rollouts/routes.py
+++ b/goosebit/api/v1/rollouts/routes.py
@@ -16,7 +16,8 @@ router = APIRouter(prefix="/rollouts", tags=["rollouts"])
     dependencies=[Security(validate_user_permissions, scopes=["rollout.read"])],
 )
 async def rollouts_get(_: Request) -> RolloutsResponse:
-    return await RolloutsResponse.convert(await Rollout.all().prefetch_related("software"))
+    rollouts = await Rollout.all().prefetch_related("software", "software__compatibility")
+    return RolloutsResponse(rollouts=rollouts)
 
 
 @router.post(

--- a/goosebit/api/v1/software/responses.py
+++ b/goosebit/api/v1/software/responses.py
@@ -1,16 +1,9 @@
 from __future__ import annotations
 
-import asyncio
-
 from pydantic import BaseModel
 
-from goosebit.db.models import Software
 from goosebit.schema.software import SoftwareSchema
 
 
 class SoftwareResponse(BaseModel):
     software: list[SoftwareSchema]
-
-    @classmethod
-    async def convert(cls, software: list[Software]):
-        return cls(software=await asyncio.gather(*[SoftwareSchema.convert(f) for f in software]))

--- a/goosebit/api/v1/software/routes.py
+++ b/goosebit/api/v1/software/routes.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import random
 import string
 
@@ -22,7 +24,8 @@ router = APIRouter(prefix="/software", tags=["software"])
     dependencies=[Security(validate_user_permissions, scopes=["software.read"])],
 )
 async def software_get(_: Request) -> SoftwareResponse:
-    return await SoftwareResponse.convert(await Software.all().prefetch_related("compatibility"))
+    software = await Software.all().prefetch_related("compatibility")
+    return SoftwareResponse(software=software)
 
 
 @router.delete(

--- a/goosebit/db/models.py
+++ b/goosebit/db/models.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from enum import IntEnum
 from typing import Self
 from urllib.parse import unquote, urlparse

--- a/goosebit/schema/devices.py
+++ b/goosebit/schema/devices.py
@@ -4,10 +4,11 @@ import time
 from enum import Enum, IntEnum, StrEnum
 from typing import Annotated
 
-from pydantic import BaseModel, BeforeValidator, computed_field
+from pydantic import BaseModel, BeforeValidator, ConfigDict, Field, computed_field
 
-from goosebit.db.models import Device, UpdateModeEnum, UpdateStateEnum
-from goosebit.updater.manager import get_update_manager
+from goosebit.db.models import UpdateModeEnum, UpdateStateEnum
+from goosebit.schema.software import HardwareSchema, SoftwareSchema
+from goosebit.updater.manager import DeviceUpdateManager
 
 
 class ConvertableEnum(StrEnum):
@@ -26,48 +27,51 @@ UpdateModeSchema = enum_factory("UpdateModeSchema", UpdateModeEnum)
 
 
 class DeviceSchema(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
     uuid: str
     name: str | None
     sw_version: str | None
-    sw_target_version: str | None
-    sw_assigned: int | None
-    hw_model: str
-    hw_revision: str
+
+    assigned_software: SoftwareSchema | None = Field(exclude=True)
+    hardware: HardwareSchema | None = Field(exclude=True)
+
     feed: str
     progress: int | None
     last_state: Annotated[UpdateStateSchema, BeforeValidator(UpdateStateSchema.convert)]  # type: ignore[valid-type]
     update_mode: Annotated[UpdateModeSchema, BeforeValidator(UpdateModeSchema.convert)]  # type: ignore[valid-type]
     force_update: bool
     last_ip: str | None
-    last_seen: int | None
-    poll_seconds: int
+    last_seen: Annotated[
+        int | None, BeforeValidator(lambda last_seen: round(time.time() - last_seen) if last_seen is not None else None)
+    ]
 
-    @computed_field
+    @computed_field  # type: ignore[misc]
+    @property
     def online(self) -> bool | None:
         return self.last_seen < self.poll_seconds if self.last_seen is not None else None
 
-    @classmethod
-    async def convert(cls, device: Device):
-        manager = await get_update_manager(device.uuid)
-        _, target_software = await manager.get_update()
-        last_seen = device.last_seen
-        if last_seen is not None:
-            last_seen = round(time.time() - device.last_seen)
+    @computed_field  # type: ignore[misc]
+    @property
+    def sw_target_version(self) -> str | None:
+        return self.assigned_software.version if self.assigned_software is not None else None
 
-        return cls(
-            uuid=device.uuid,
-            name=device.name,
-            sw_version=device.sw_version,
-            sw_target_version=(target_software.version if target_software is not None else None),
-            sw_assigned=(device.assigned_software.id if device.assigned_software is not None else None),
-            hw_model=device.hardware.model,
-            hw_revision=device.hardware.revision,
-            feed=device.feed,
-            progress=device.progress,
-            last_state=device.last_state,
-            update_mode=device.update_mode,
-            force_update=device.force_update,
-            last_ip=device.last_ip,
-            last_seen=last_seen,
-            poll_seconds=manager.poll_seconds,
-        )
+    @computed_field  # type: ignore[misc]
+    @property
+    def sw_assigned(self) -> int | None:
+        return self.assigned_software.id if self.assigned_software is not None else None
+
+    @computed_field  # type: ignore[misc]
+    @property
+    def hw_model(self) -> str | None:
+        return self.hardware.model if self.hardware is not None else None
+
+    @computed_field  # type: ignore[misc]
+    @property
+    def hw_revision(self) -> str | None:
+        return self.hardware.revision if self.hardware is not None else None
+
+    @computed_field  # type: ignore[misc]
+    @property
+    def poll_seconds(self) -> int:
+        return DeviceUpdateManager(self.uuid).poll_seconds

--- a/goosebit/ui/bff/devices/responses.py
+++ b/goosebit/ui/bff/devices/responses.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import asyncio
-
 from fastapi.requests import Request
 from pydantic import BaseModel, Field
 
@@ -33,7 +31,7 @@ class BFFDeviceResponse(BaseModel):
             query = query.order_by(f"{'-' if order_dir == 'desc' else ''}{order_column}")
 
         filtered_records = await query.count()
-        devices = await query.offset(start).limit(length).all()
-        data = await asyncio.gather(*[DeviceSchema.convert(d) for d in devices])
+        devices = await query.offset(start).limit(length).all().prefetch_related("assigned_software", "hardware")
+        data = [DeviceSchema.model_validate(d) for d in devices]
 
         return cls(data=data, draw=draw, records_total=total_records, records_filtered=filtered_records)

--- a/goosebit/ui/bff/rollouts/responses.py
+++ b/goosebit/ui/bff/rollouts/responses.py
@@ -1,5 +1,3 @@
-import asyncio
-
 from fastapi.requests import Request
 from pydantic import BaseModel, Field
 
@@ -32,6 +30,6 @@ class BFFRolloutsResponse(BaseModel):
 
         filtered_records = await query.count()
         rollouts = await query.offset(start).limit(length).all()
-        data = await asyncio.gather(*[RolloutSchema.convert(r) for r in rollouts])
+        data = [RolloutSchema.model_validate(r) for r in rollouts]
 
         return cls(data=data, draw=draw, records_total=total_records, records_filtered=filtered_records)

--- a/goosebit/ui/bff/rollouts/routes.py
+++ b/goosebit/ui/bff/rollouts/routes.py
@@ -19,7 +19,7 @@ async def rollouts_get(request: Request) -> BFFRolloutsResponse:
     def search_filter(search_value):
         return Q(name__icontains=search_value) | Q(feed__icontains=search_value)
 
-    query = Rollout.all().prefetch_related("software")
+    query = Rollout.all().prefetch_related("software", "software__compatibility")
     total_records = await Rollout.all().count()
 
     return await BFFRolloutsResponse.convert(request, query, search_filter, total_records)

--- a/goosebit/ui/bff/software/responses.py
+++ b/goosebit/ui/bff/software/responses.py
@@ -1,5 +1,3 @@
-import asyncio
-
 from fastapi.requests import Request
 from pydantic import BaseModel, Field
 
@@ -32,6 +30,6 @@ class BFFSoftwareResponse(BaseModel):
 
         filtered_records = await query.count()
         devices = await query.offset(start).limit(length).all()
-        data = await asyncio.gather(*[SoftwareSchema.convert(d) for d in devices])
+        data = [SoftwareSchema.model_validate(d) for d in devices]
 
         return cls(data=data, draw=draw, records_total=total_records, records_filtered=filtered_records)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,6 @@ pre-commit = "^3.6.2"
 flake8 = "7.1.0"
 mypy = "^1.11.2"
 types-pyyaml = "^6.0.12.20240808"
-types-aiofiles = "^24.1.0.20240626"
 
 [tool.poetry.group.docs.dependencies]
 mkdocs = "^1.6.0"


### PR DESCRIPTION
`pydantic` models have a deprecated `from_orm` method, which is designed to parse DB models into the schema. This was superseded by `model_validate`, which does the same thing when the schema config `from_attributes` value is true. Migrating to using this simplifies the method of parsing DB models, and will eventually allow the schemas to be used internally instead of the DB models.

Reference here - https://docs.pydantic.dev/2.0/usage/models/#arbitrary-class-instances

The goal here is to get to the point where we can pass around arbitrary abstract software types internally, which will allow hooking the software that a device should receive.