### PR TITLE
Fix version parsing in SWU

### DIFF
--- a/goosebit/updates/__init__.py
+++ b/goosebit/updates/__init__.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+import logging
 from urllib.parse import unquote, urlparse
 from urllib.request import url2pathname
 
+import semver
 from anyio import Path
 from fastapi import HTTPException
 from fastapi.requests import Request
@@ -13,10 +15,9 @@ from goosebit.updater.manager import UpdateManager
 
 from ..settings import config
 from . import swdesc
-import semver
-import logging
 
 logger = logging.getLogger(__name__)
+
 
 async def create_software_update(uri: str, temp_file: Path | None) -> Software:
     parsed_uri = urlparse(uri)

--- a/goosebit/updates/__init__.py
+++ b/goosebit/updates/__init__.py
@@ -13,7 +13,10 @@ from goosebit.updater.manager import UpdateManager
 
 from ..settings import config
 from . import swdesc
+import semver
+import logging
 
+logger = logging.getLogger(__name__)
 
 async def create_software_update(uri: str, temp_file: Path | None) -> Software:
     parsed_uri = urlparse(uri)
@@ -26,6 +29,10 @@ async def create_software_update(uri: str, temp_file: Path | None) -> Software:
             update_info = await swdesc.parse_file(temp_file)
         except Exception:
             raise HTTPException(422, "Software swu header cannot be parsed")
+        try:
+            update_info["version"] = semver.Version.parse(update_info["version"])
+        except ValueError as e:
+            logging.warning(f"fallback to legacy version {e}")
 
     elif parsed_uri.scheme.startswith("http"):
         try:

--- a/goosebit/updates/swdesc.py
+++ b/goosebit/updates/swdesc.py
@@ -23,7 +23,7 @@ def _append_compatibility(boardname, value, compatibility):
 def parse_descriptor(swdesc: libconf.AttrDict[Any, Any | None]):
     swdesc_attrs = {}
     try:
-        swdesc_attrs["version"] = semver.Version.parse(swdesc["software"]["version"])
+        swdesc_attrs["version"] = swdesc["software"]["version"]
         compatibility: list[dict[str, str]] = []
         _append_compatibility("default", swdesc["software"], compatibility)
 


### PR DESCRIPTION
The parser raises an error if version is not set according to the semantic version rules. However, this is not mandatory in SWUpdate and any version string is allowed. Set version from sw-description if a semantic version cannot be parsed.
