### PR TITLE
Handle DataTables query parameters with `Depends`

### DIFF
--- a/goosebit/ui/bff/common/requests.py
+++ b/goosebit/ui/bff/common/requests.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from enum import StrEnum
+
+from pydantic import BaseModel, computed_field
+
+
+class DataTableSearchSchema(BaseModel):
+    value: str | None = None
+    regex: bool | None = False
+
+
+class DataTableColumnSchema(BaseModel):
+    data: str | None
+    name: str | None = None
+    searchable: bool | None = None
+    orderable: bool | None = None
+    search: DataTableSearchSchema = DataTableSearchSchema()
+
+
+class DataTableOrderDirection(StrEnum):
+    ASCENDING = "asc"
+    DESCENDING = "desc"
+
+
+class DataTableOrderSchema(BaseModel):
+    column: int | None = None
+    dir: DataTableOrderDirection | None = None
+    name: str | None = None
+
+    @computed_field  # type: ignore[misc]
+    @property
+    def direction(self) -> str:
+        return "-" if self.dir == DataTableOrderDirection.DESCENDING else ""
+
+
+class DataTableRequest(BaseModel):
+    draw: int = 1
+    columns: list[DataTableColumnSchema] = list()
+    order: list[DataTableOrderSchema] = list()
+    start: int = 0
+    length: int = 10
+    search: DataTableSearchSchema = DataTableSearchSchema()
+
+    @computed_field  # type: ignore[misc]
+    @property
+    def order_query(self) -> str | None:
+        try:
+            column = self.order[0].column
+            if column is None:
+                return None
+            if self.columns[column].name is None:
+                return None
+            return f"{self.order[0].direction}{self.columns[column].data}"
+        except LookupError:
+            return None

--- a/goosebit/ui/bff/common/util.py
+++ b/goosebit/ui/bff/common/util.py
@@ -1,0 +1,32 @@
+from fastapi.requests import Request
+
+from goosebit.ui.bff.common.requests import DataTableRequest
+
+
+def parse_datatables_query(request: Request):
+    # parsing adapted from https://github.com/ziiiio/datatable_ajax_request_parser
+
+    result = {}
+    for key, value in request.query_params.items():
+        key_list = key.replace("][", ";").replace("[", ";").replace("]", "").split(";")
+
+        if len(key_list) == 0:
+            continue
+
+        if len(key_list) == 1:
+            result[key] = value[0] if len(value) == 1 else value
+            continue
+
+        temp_dict = result
+        for inner_key in key_list[:-1]:
+            if inner_key not in temp_dict:
+                temp_dict.update({inner_key: {}})
+            temp_dict = temp_dict[inner_key]
+        temp_dict[key_list[-1]] = value[0] if len(value) == 1 else value
+
+    if result.get("columns"):
+        result["columns"] = [result["columns"][str(idx)] for idx, _ in enumerate(result["columns"])]
+    if result.get("order"):
+        result["order"] = [result["order"][str(idx)] for idx, _ in enumerate(result["order"])]
+
+    return DataTableRequest.model_validate(result)

--- a/goosebit/ui/bff/devices/responses.py
+++ b/goosebit/ui/bff/devices/responses.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
-from fastapi.requests import Request
+from typing import Callable
+
 from pydantic import BaseModel, Field
+from tortoise.queryset import QuerySet
 
 from goosebit.schema.devices import DeviceSchema
+from goosebit.ui.bff.common.requests import DataTableRequest
 
 
 class BFFDeviceResponse(BaseModel):
@@ -13,25 +16,16 @@ class BFFDeviceResponse(BaseModel):
     records_filtered: int = Field(serialization_alias="recordsFiltered")
 
     @classmethod
-    async def convert(cls, request: Request, query, search_filter, total_records):
-        params = request.query_params
+    async def convert(cls, dt_query: DataTableRequest, query: QuerySet, search_filter: Callable):
+        total_records = await query.count()
+        if dt_query.search.value:
+            query = query.filter(search_filter(dt_query.search.value))
 
-        draw = int(params.get("draw", 1))
-        start = int(params.get("start", 0))
-        length = int(params.get("length", 10))
-        search_value = params.get("search[value]", None)
-        order_column_index = params.get("order[0][column]", None)
-        order_column = params.get(f"columns[{order_column_index}][data]", None)
-        order_dir = params.get("order[0][dir]", None)
-
-        if search_value:
-            query = query.filter(search_filter(search_value))
-
-        if order_column:
-            query = query.order_by(f"{'-' if order_dir == 'desc' else ''}{order_column}")
+        if dt_query.order_query:
+            query = query.order_by(dt_query.order_query)
 
         filtered_records = await query.count()
-        devices = await query.offset(start).limit(length).all().prefetch_related("assigned_software", "hardware")
+        devices = await query.offset(dt_query.start).limit(dt_query.length).all()
         data = [DeviceSchema.model_validate(d) for d in devices]
 
-        return cls(data=data, draw=draw, records_total=total_records, records_filtered=filtered_records)
+        return cls(data=data, draw=dt_query.draw, records_total=total_records, records_filtered=filtered_records)

--- a/goosebit/ui/bff/rollouts/responses.py
+++ b/goosebit/ui/bff/rollouts/responses.py
@@ -1,7 +1,10 @@
-from fastapi.requests import Request
+from typing import Callable
+
 from pydantic import BaseModel, Field
+from tortoise.queryset import QuerySet
 
 from goosebit.schema.rollouts import RolloutSchema
+from goosebit.ui.bff.common.requests import DataTableRequest
 
 
 class BFFRolloutsResponse(BaseModel):
@@ -11,25 +14,16 @@ class BFFRolloutsResponse(BaseModel):
     records_filtered: int = Field(serialization_alias="recordsFiltered")
 
     @classmethod
-    async def convert(cls, request: Request, query, search_filter, total_records):
-        params = request.query_params
+    async def convert(cls, dt_query: DataTableRequest, query: QuerySet, search_filter: Callable):
+        total_records = await query.count()
+        if dt_query.search.value:
+            query = query.filter(search_filter(dt_query.search.value))
 
-        draw = int(params.get("draw", 1))
-        start = int(params.get("start", 0))
-        length = int(params.get("length", 10))
-        search_value = params.get("search[value]", None)
-        order_column_index = params.get("order[0][column]", None)
-        order_column = params.get(f"columns[{order_column_index}][data]", None)
-        order_dir = params.get("order[0][dir]", None)
-
-        if search_value:
-            query = query.filter(search_filter(search_value))
-
-        if order_column:
-            query = query.order_by(f"{'-' if order_dir == 'desc' else ''}{order_column}")
+        if dt_query.order_query:
+            query = query.order_by(dt_query.order_query)
 
         filtered_records = await query.count()
-        rollouts = await query.offset(start).limit(length).all()
+        rollouts = await query.offset(dt_query.start).limit(dt_query.length).all()
         data = [RolloutSchema.model_validate(r) for r in rollouts]
 
-        return cls(data=data, draw=draw, records_total=total_records, records_filtered=filtered_records)
+        return cls(data=data, draw=dt_query.draw, records_total=total_records, records_filtered=filtered_records)

--- a/goosebit/ui/bff/rollouts/routes.py
+++ b/goosebit/ui/bff/rollouts/routes.py
@@ -1,10 +1,13 @@
-from fastapi import APIRouter, Security
-from fastapi.requests import Request
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Security
 from tortoise.expressions import Q
 
 from goosebit.api.v1.rollouts import routes
 from goosebit.auth import validate_user_permissions
 from goosebit.db.models import Rollout
+from goosebit.ui.bff.common.requests import DataTableRequest
+from goosebit.ui.bff.common.util import parse_datatables_query
 
 from .responses import BFFRolloutsResponse
 
@@ -15,14 +18,13 @@ router = APIRouter(prefix="/rollouts")
     "",
     dependencies=[Security(validate_user_permissions, scopes=["rollout.read"])],
 )
-async def rollouts_get(request: Request) -> BFFRolloutsResponse:
+async def rollouts_get(dt_query: Annotated[DataTableRequest, Depends(parse_datatables_query)]) -> BFFRolloutsResponse:
     def search_filter(search_value):
         return Q(name__icontains=search_value) | Q(feed__icontains=search_value)
 
     query = Rollout.all().prefetch_related("software", "software__compatibility")
-    total_records = await Rollout.all().count()
 
-    return await BFFRolloutsResponse.convert(request, query, search_filter, total_records)
+    return await BFFRolloutsResponse.convert(dt_query, query, search_filter)
 
 
 router.add_api_route(


### PR DESCRIPTION
Use `Pydantic` and `Depends` to automatically parse the DataTables AJAX request to a typed format.

Precursor to a fix required in #138, which should use query parameters to validate software compatibility.