### PR TITLE
Clean up Docker Compose file

### DIFF
--- a/docker/demo/docker-compose.yml
+++ b/docker/demo/docker-compose.yml
@@ -33,14 +33,9 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
-    deploy:
-      resources:
-        limits:
-          memory: 512M
 
   nginx:
     image: nginx:1.27.0-alpine
-    restart: unless-stopped
     ports:
       - "443:443"
     volumes:


### PR DESCRIPTION
The `deploy` and (inconsistent) `restart` configuration is not necessary for the demo.