### PR TITLE
Use more flexible version parsing

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -93,7 +93,7 @@ async def test_data(db):
         await software_beta.compatibility.add(compatibility)
 
         software_release = await Software.create(
-            version="1.0.0",
+            version="1",
             hash="dummy",
             size=1200,
             uri=uri,

--- a/goosebit/db/models.py
+++ b/goosebit/db/models.py
@@ -138,7 +138,7 @@ class Software(Model):
             return None
         return sorted(
             updates,
-            key=lambda x: semver.Version.parse(x.version),
+            key=lambda x: semver.Version.parse(x.version, optional_minor_and_patch=True),
             reverse=True,
         )[0]
 

--- a/goosebit/updates/swdesc.py
+++ b/goosebit/updates/swdesc.py
@@ -23,7 +23,7 @@ def _append_compatibility(boardname, value, compatibility):
 def parse_descriptor(swdesc: libconf.AttrDict[Any, Any | None]):
     swdesc_attrs = {}
     try:
-        swdesc_attrs["version"] = semver.Version.parse(swdesc["software"]["version"])
+        swdesc_attrs["version"] = semver.Version.parse(swdesc["software"]["version"], optional_minor_and_patch=True)
         compatibility: list[dict[str, str]] = []
         _append_compatibility("default", swdesc["software"], compatibility)
 

--- a/tests/updates/test_swdesc.py
+++ b/tests/updates/test_swdesc.py
@@ -10,7 +10,7 @@ def test_parse_descriptor_simple():
     desc = AttrDict(
         {
             "software": {
-                "version": "1.0.0",
+                "version": "1.0",
                 "description": "Software update for XXXXX Project",
                 "hardware-compatibility": ["1.0", "1.2"],
             }


### PR DESCRIPTION
SWUpdate does not restrict versions to follow semver.org. So using a more flexible version parsing by making minor and patch elements optional.

Addresses same issue as #139