### PR TITLE
UI improvements. default column ordering and remove custom state loading

### DIFF
--- a/goosebit/ui/static/js/devices.js
+++ b/goosebit/ui/static/js/devices.js
@@ -6,7 +6,7 @@ document.addEventListener("DOMContentLoaded", async () => {
         paging: true,
         processing: false,
         serverSide: true,
-        order: [],
+        order: { name: "uuid", dir: "asc" },
         scrollCollapse: true,
         scroller: true,
         scrollY: "65vh",
@@ -52,7 +52,7 @@ document.addEventListener("DOMContentLoaded", async () => {
                     return data;
                 },
             },
-            { data: "uuid", searchable: true, orderable: true },
+            { data: "uuid", name: "uuid", searchable: true, orderable: true },
             { data: "name", searchable: true, orderable: true },
             { data: "hw_model" },
             { data: "hw_revision" },

--- a/goosebit/ui/static/js/devices.js
+++ b/goosebit/ui/static/js/devices.js
@@ -11,15 +11,6 @@ document.addEventListener("DOMContentLoaded", async () => {
         scroller: true,
         scrollY: "65vh",
         stateSave: true,
-        stateLoadParams: (settings, data) => {
-            // if save state is older than last breaking code change...
-            if (data.time <= 1722434189000) {
-                // ... delete it
-                for (const key of Object.keys(data)) {
-                    delete data[key];
-                }
-            }
-        },
         select: true,
         rowId: "uuid",
         ajax: {

--- a/goosebit/ui/static/js/rollouts.js
+++ b/goosebit/ui/static/js/rollouts.js
@@ -6,7 +6,10 @@ document.addEventListener("DOMContentLoaded", async () => {
         paging: true,
         processing: true,
         serverSide: true,
-        order: [1, "desc"],
+        order: {
+            name: "created_at",
+            dir: "desc",
+        },
         scrollCollapse: true,
         scroller: true,
         scrollY: "65vh",
@@ -38,7 +41,12 @@ document.addEventListener("DOMContentLoaded", async () => {
         ],
         columns: [
             { data: "id", visible: false },
-            { data: "created_at", orderable: true, render: (data) => new Date(data).toLocaleString() },
+            {
+                data: "created_at",
+                name: "created_at",
+                orderable: true,
+                render: (data) => new Date(data).toLocaleString(),
+            },
             { data: "name", searchable: true, orderable: true },
             { data: "feed", searchable: true, orderable: true },
             { data: "sw_file" },

--- a/goosebit/ui/static/js/rollouts.js
+++ b/goosebit/ui/static/js/rollouts.js
@@ -14,15 +14,6 @@ document.addEventListener("DOMContentLoaded", async () => {
         scroller: true,
         scrollY: "65vh",
         stateSave: true,
-        stateLoadParams: (settings, data) => {
-            // if save state is older than last breaking code change...
-            if (data.time <= 1722413708000) {
-                // ... delete it
-                for (const key of Object.keys(data)) {
-                    delete data[key];
-                }
-            }
-        },
         select: true,
         rowId: "id",
         ajax: {

--- a/goosebit/ui/static/js/software.js
+++ b/goosebit/ui/static/js/software.js
@@ -172,7 +172,10 @@ document.addEventListener("DOMContentLoaded", () => {
         paging: true,
         processing: false,
         serverSide: true,
-        order: [2, "desc"],
+        order: {
+            name: "version",
+            dir: "desc",
+        },
         scrollCollapse: true,
         scroller: true,
         scrollY: "60vh",
@@ -204,7 +207,7 @@ document.addEventListener("DOMContentLoaded", () => {
         columns: [
             { data: "id", visible: false },
             { data: "name" },
-            { data: "version", searchable: true, orderable: true },
+            { data: "version", name: "version", searchable: true, orderable: true },
             {
                 data: "compatibility",
                 render: (data) => {

--- a/goosebit/ui/static/js/software.js
+++ b/goosebit/ui/static/js/software.js
@@ -180,15 +180,6 @@ document.addEventListener("DOMContentLoaded", () => {
         scroller: true,
         scrollY: "60vh",
         stateSave: true,
-        stateLoadParams: (settings, data) => {
-            // if save state is older than last breaking code change...
-            if (data.time <= 1722415428000) {
-                // ... delete it
-                for (const key of Object.keys(data)) {
-                    delete data[key];
-                }
-            }
-        },
         ajax: {
             url: "/ui/bff/software",
             contentType: "application/json",


### PR DESCRIPTION
Column ordering will prevent device table entries to jump around between reloads. Tried to find an initial order that feels natural.

Also removed my custom state load logic. State only stays valid for two hours by default.