### PR TITLE
Fix online status ("Up") flickering bug

### DIFF
--- a/goosebit/schema/devices.py
+++ b/goosebit/schema/devices.py
@@ -49,7 +49,7 @@ class DeviceSchema(BaseModel):
     @computed_field  # type: ignore[misc]
     @property
     def online(self) -> bool | None:
-        return self.last_seen < self.poll_seconds if self.last_seen is not None else None
+        return self.last_seen < (self.poll_seconds + 10) if self.last_seen is not None else None
 
     @computed_field  # type: ignore[misc]
     @property

--- a/goosebit/updater/manager.py
+++ b/goosebit/updater/manager.py
@@ -265,19 +265,15 @@ class DeviceUpdateManager(UpdateManager):
 
         if software is None:
             handling_type = HandlingType.SKIP
-            self.poll_time = config.poll_time_default
 
         elif software.version == device.sw_version and not device.force_update:
             handling_type = HandlingType.SKIP
-            self.poll_time = config.poll_time_default
 
         elif device.last_state == UpdateStateEnum.ERROR and not device.force_update:
             handling_type = HandlingType.SKIP
-            self.poll_time = config.poll_time_default
 
         else:
             handling_type = HandlingType.FORCED
-            self.poll_time = config.poll_time_updating
 
             if device.log_complete:
                 await self.update_log_complete(False)

--- a/goosebit/updater/manager.py
+++ b/goosebit/updater/manager.py
@@ -83,9 +83,7 @@ class UpdateManager(ABC):
     @asynccontextmanager
     async def subscribe_log(self, callback: Callable):
         device = await self.get_device()
-        subscribers = self.log_subscribers
-        subscribers.append(callback)
-        self.log_subscribers = subscribers
+        self.log_subscribers.append(callback)
         if device is not None:
             await callback(device.last_log)
         try:
@@ -93,9 +91,7 @@ class UpdateManager(ABC):
         except asyncio.CancelledError:
             pass
         finally:
-            subscribers = self.log_subscribers
-            subscribers.remove(callback)
-            self.log_subscribers = subscribers
+            self.log_subscribers.remove(callback)
 
     @property
     def poll_seconds(self):


### PR DESCRIPTION
Fixes: #137

PR does two things
1. Includes adding a 10 seconds safety margin from PR #149. 
2. Prevents poll time to be adjusted when assigning software to device

These two things together should get rid of the flickering.

Note: the log file handling likely needs similar changes. Will create a new ticket for the log files as it could require some discussions first.