### PR TITLE
Allow configuring ip tracking by loading columns from bff API

### DIFF
--- a/goosebit.yaml
+++ b/goosebit.yaml
@@ -16,6 +16,9 @@ poll_time_default: 00:01:00
 # and device logs get updated.
 poll_time_updating: 00:00:05
 
+# Whether to track the IP of the device when it polls.  Useful for debugging, but can be turned off for privacy.
+# track_device_ip: true
+
 # Secret key used for parsing user sessions. It is HIGHLY advised to pass this as an environment variable instead.
 # Defaults to a randomized value. If this value is not set, user sessions will not persist when app restarts.
 # secret_key: my_very_top_secret_key123

--- a/goosebit/__init__.py
+++ b/goosebit/__init__.py
@@ -14,6 +14,7 @@ from tortoise.exceptions import ValidationError
 from goosebit import api, db, realtime, ui, updater
 from goosebit.api.telemetry import metrics
 from goosebit.auth import get_user_from_request, login_user, redirect_if_authenticated
+from goosebit.settings import config
 from goosebit.ui.nav import nav
 from goosebit.ui.static import static
 from goosebit.ui.templates import templates
@@ -74,6 +75,12 @@ async def attach_user(request: Request, call_next):
 @app.middleware("http")
 async def attach_nav(request: Request, call_next):
     request.scope["nav"] = nav.get()
+    return await call_next(request)
+
+
+@app.middleware("http")
+async def attach_config(request: Request, call_next):
+    request.scope["config"] = config
     return await call_next(request)
 
 

--- a/goosebit/settings/schema.py
+++ b/goosebit/settings/schema.py
@@ -52,6 +52,8 @@ class GooseBitSettings(BaseSettings):
 
     logging: dict = LOGGING_DEFAULT
 
+    track_device_ip: bool = True
+
     @classmethod
     def settings_customise_sources(
         cls,

--- a/goosebit/ui/bff/common/responses.py
+++ b/goosebit/ui/bff/common/responses.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class DTColumnDescription(BaseModel):
+    title: str
+    data: str
+    name: str | None = None
+
+    searchable: bool | None = None
+    orderable: bool | None = None
+
+
+class DTColumns(BaseModel):
+    columns: list[DTColumnDescription]

--- a/goosebit/ui/static/js/devices.js
+++ b/goosebit/ui/static/js/devices.js
@@ -1,6 +1,52 @@
 let dataTable;
 
+const renderFunctions = {
+    online: (data, type) => {
+        if (type === "display" || type === "filter") {
+            const color = data ? "success" : "danger";
+            return `
+            <div class="text-${color}">
+                ●
+            </div>
+            `;
+        }
+        return data;
+    },
+    force_update: (data, type) => {
+        if (type === "display" || type === "filter") {
+            const color = data ? "success" : "muted";
+            return `
+            <div class="text-${color}">
+                ●
+            </div>
+            `;
+        }
+        return data;
+    },
+    progress: (data, type) => {
+        if (type === "display" || type === "filter") {
+            return data ? `${data}%` : "-";
+        }
+        return data;
+    },
+    last_seen: (data, type) => {
+        if (type === "display" || type === "filter") {
+            return secondsToRecentDate(data);
+        }
+        return data;
+    },
+};
+
 document.addEventListener("DOMContentLoaded", async () => {
+    const columnConfig = await get_request("/ui/bff/devices/columns");
+    for (const col in columnConfig.columns) {
+        const colDesc = columnConfig.columns[col];
+        const colName = colDesc.data;
+        if (renderFunctions[colName]) {
+            columnConfig.columns[col].render = renderFunctions[colName];
+        }
+    }
+
     dataTable = new DataTable("#device-table", {
         responsive: true,
         paging: true,
@@ -32,64 +78,7 @@ document.addEventListener("DOMContentLoaded", async () => {
                 render: (data) => data || "-",
             },
         ],
-        columns: [
-            {
-                data: "online",
-                render: (data, type) => {
-                    if (type === "display" || type === "filter") {
-                        const color = data ? "success" : "danger";
-                        return `
-                        <div class="text-${color}">
-                            ●
-                        </div>
-                        `;
-                    }
-                    return data;
-                },
-            },
-            { data: "uuid", name: "uuid", searchable: true, orderable: true },
-            { data: "name", name: "name", searchable: true, orderable: true },
-            { data: "hw_model" },
-            { data: "hw_revision" },
-            { data: "feed", name: "feed", searchable: true, orderable: true },
-            { data: "sw_version", name: "sw_version", searchable: true, orderable: true },
-            { data: "sw_target_version" },
-            { data: "update_mode", name: "update_mode", searchable: true, orderable: true },
-            { data: "last_state", name: "last_state", searchable: true, orderable: true },
-            {
-                data: "force_update",
-                render: (data, type) => {
-                    if (type === "display" || type === "filter") {
-                        const color = data ? "success" : "muted";
-                        return `
-                        <div class="text-${color}">
-                            ●
-                        </div>
-                        `;
-                    }
-                    return data;
-                },
-            },
-            {
-                data: "progress",
-                render: (data, type) => {
-                    if (type === "display" || type === "filter") {
-                        return data ? `${data}%` : "-";
-                    }
-                    return data;
-                },
-            },
-            { data: "last_ip" },
-            {
-                data: "last_seen",
-                render: (data, type) => {
-                    if (type === "display" || type === "filter") {
-                        return secondsToRecentDate(data);
-                    }
-                    return data;
-                },
-            },
-        ],
+        columns: columnConfig.columns,
         layout: {
             top1Start: {
                 buttons: [

--- a/goosebit/ui/static/js/util.js
+++ b/goosebit/ui/static/js/util.js
@@ -64,6 +64,26 @@ async function updateSoftwareSelection(devices = null) {
     }
 }
 
+async function get_request(url) {
+    const response = await fetch(url, {
+        method: "GET",
+    });
+
+    const result = await response.json();
+    if (!response.ok) {
+        if (result.detail) {
+            Swal.fire({
+                title: "Warning",
+                text: result.detail,
+                icon: "warning",
+                confirmButtonText: "Understood",
+            });
+        }
+
+        throw new Error(`POST ${url} failed for ${JSON.stringify(object)}`);
+    }
+    return result;
+}
 async function post_request(url, object) {
     const response = await fetch(url, {
         method: "POST",

--- a/goosebit/ui/templates/devices.html.jinja
+++ b/goosebit/ui/templates/devices.html.jinja
@@ -4,26 +4,6 @@
         <div class="row p-2 d-flex justify-content-center">
             <div class="col">
                 <table id="device-table" class="table table-hover">
-                    <thead>
-                        <tr>
-                            <th>Up</th>
-                            <th>UUID</th>
-                            <th>Name</th>
-                            <th>Model</th>
-                            <th>Revision</th>
-                            <th>Feed</th>
-                            <th>Installed Software</th>
-                            <th>Target Software</th>
-                            <th>Update Mode</th>
-                            <th>State</th>
-                            <th>Force Update</th>
-                            <th>Progress</th>
-                            <th>Last IP</th>
-                            <th>Last Seen</th>
-                        </tr>
-                    </thead>
-                    <tbody id="devices-list">
-                    </tbody>
                 </table>
             </div>
         </div>

--- a/goosebit/updater/manager.py
+++ b/goosebit/updater/manager.py
@@ -59,7 +59,7 @@ class UpdateManager(ABC):
     async def update_device_state(self, state: UpdateStateEnum) -> None:
         return
 
-    async def update_last_connection(self, last_seen: int, last_ip: str) -> None:
+    async def update_last_connection(self, last_seen: int, last_ip: str | None = None) -> None:
         return
 
     async def update_update(self, update_mode: UpdateModeEnum, software: Software | None):
@@ -175,10 +175,12 @@ class DeviceUpdateManager(UpdateManager):
         device.last_state = state
         await self.save_device(device, update_fields=["last_state"])
 
-    async def update_last_connection(self, last_seen: int, last_ip: str) -> None:
+    async def update_last_connection(self, last_seen: int, last_ip: str | None = None) -> None:
         device = await self.get_device()
         device.last_seen = last_seen
-        if ":" in last_ip:
+        if last_ip is None:
+            await self.save_device(device, update_fields=["last_seen"])
+        elif ":" in last_ip:
             device.last_ipv6 = last_ip
             await self.save_device(device, update_fields=["last_seen", "last_ipv6"])
         else:

--- a/goosebit/updater/routes.py
+++ b/goosebit/updater/routes.py
@@ -3,14 +3,18 @@ import time
 from fastapi import APIRouter, Depends
 from fastapi.requests import Request
 
+from goosebit.settings import config
+
 from . import controller
 from .manager import get_update_manager
 
 
 async def log_last_connection(request: Request, dev_id: str):
-    host = request.client.host
     updater = await get_update_manager(dev_id)
-    await updater.update_last_connection(round(time.time()), host)
+    if config.track_device_ip:
+        await updater.update_last_connection(round(time.time()), request.client.host)
+    else:
+        await updater.update_last_connection(round(time.time()))
 
 
 router = APIRouter(


### PR DESCRIPTION
IP tracking can now be disabled with the `track_device_ip` config flag. The UI also has to hide this column, as it will no longer show up in data. To handle this, the table columns are dynamically created with a request to the bff API.

Fixes #164