### PR TITLE
Fix log handling issues with websocket auth and connection closing

### DIFF
--- a/goosebit/auth/__init__.py
+++ b/goosebit/auth/__init__.py
@@ -16,7 +16,11 @@ from goosebit.settings.schema import User
 logger = logging.getLogger(__name__)
 
 
-oauth2_auth = OAuth2PasswordBearer(tokenUrl="login", auto_error=False)
+oauth2_bearer = OAuth2PasswordBearer(tokenUrl="login", auto_error=False)
+
+
+async def oauth2_auth(connection: HTTPConnection):
+    return await oauth2_bearer(connection)
 
 
 async def session_auth(connection: HTTPConnection) -> str:

--- a/goosebit/updater/manager.py
+++ b/goosebit/updater/manager.py
@@ -83,7 +83,11 @@ class UpdateManager(ABC):
     @asynccontextmanager
     async def subscribe_log(self, callback: Callable):
         device = await self.get_device()
-        self.log_subscribers.append(callback)
+        # do not modify, breaks when combined
+        subscribers = self.log_subscribers
+        subscribers.append(callback)
+        self.log_subscribers = subscribers
+
         if device is not None:
             await callback(device.last_log)
         try:
@@ -91,7 +95,10 @@ class UpdateManager(ABC):
         except asyncio.CancelledError:
             pass
         finally:
-            self.log_subscribers.remove(callback)
+            # do not modify, breaks when combined
+            subscribers = self.log_subscribers
+            subscribers.remove(callback)
+            self.log_subscribers = subscribers
 
     @property
     def poll_seconds(self):


### PR DESCRIPTION
Websocket authentication wasn't handling oauth properly because of a positional `Request`. Log subscribers may also break when connections are closed when the remove call is combined, needs to be separate.

Fixes #168 