### PR TITLE
Log handling rework

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -85,14 +85,6 @@ async def test_data(db):
         )
         await software_beta.compatibility.add(hardware)
 
-        software_release = await Software.create(
-            version="1",
-            hash="dummy",
-            size=1200,
-            uri=uri,
-        )
-        await software_release.compatibility.add(hardware)
-
         software_rc = await Software.create(
             version="1.0.0-rc2+build77",
             hash="dummy2",
@@ -100,6 +92,14 @@ async def test_data(db):
             uri=uri,
         )
         await software_rc.compatibility.add(hardware)
+
+        software_release = await Software.create(
+            version="1",
+            hash="dummy",
+            size=1200,
+            uri=uri,
+        )
+        await software_release.compatibility.add(hardware)
 
         rollout_default = await Rollout.create(software_id=software_release.id)
 

--- a/goosebit/db/migrations/models/1_20241109151811_update.py
+++ b/goosebit/db/migrations/models/1_20241109151811_update.py
@@ -1,0 +1,11 @@
+from tortoise import BaseDBAsyncClient
+
+
+async def upgrade(db: BaseDBAsyncClient) -> str:
+    return """
+        ALTER TABLE "device" DROP COLUMN "log_complete";"""
+
+
+async def downgrade(db: BaseDBAsyncClient) -> str:
+    return """
+        ALTER TABLE "device" ADD "log_complete" INT NOT NULL  DEFAULT 0;"""

--- a/goosebit/db/models.py
+++ b/goosebit/db/models.py
@@ -69,7 +69,6 @@ class Device(Model):
     update_mode = fields.IntEnumField(UpdateModeEnum, default=UpdateModeEnum.ROLLOUT)
     last_state = fields.IntEnumField(UpdateStateEnum, default=UpdateStateEnum.UNKNOWN)
     progress = fields.IntField(null=True)
-    log_complete = fields.BooleanField(default=False)
     last_log = fields.TextField(null=True)
     last_seen = fields.BigIntField(null=True)
     last_ip = fields.CharField(max_length=15, null=True)

--- a/goosebit/updater/controller/v1/routes.py
+++ b/goosebit/updater/controller/v1/routes.py
@@ -2,7 +2,7 @@ import logging
 
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.requests import Request
-from fastapi.responses import FileResponse, RedirectResponse, Response
+from fastapi.responses import FileResponse, Response
 
 from goosebit.db.models import Software, UpdateStateEnum
 from goosebit.settings import config
@@ -184,11 +184,11 @@ async def download_artifact(_: Request, updater: UpdateManager = Depends(get_upd
     _, software = await updater.get_update()
     if software is None:
         raise HTTPException(404)
-    if software.local:
-        return FileResponse(
-            software.path,
-            media_type="application/octet-stream",
-            filename=software.path.name,
-        )
-    else:
-        return RedirectResponse(url=software.uri)
+
+    assert software.local, "device requests local software to download"
+
+    return FileResponse(
+        software.path,
+        media_type="application/octet-stream",
+        filename=software.path.name,
+    )

--- a/goosebit/updater/controller/v1/routes.py
+++ b/goosebit/updater/controller/v1/routes.py
@@ -45,7 +45,7 @@ async def polling(request: Request, dev_id: str, updater: UpdateManager = Depend
 
     elif device.last_state == UpdateStateEnum.ERROR and not device.force_update:
         sleep = config.poll_time_default
-        logger.warning(f"Skip: device in error state, device={updater.dev_id}")
+        logger.info(f"Skip: device in error state, device={updater.dev_id}")
 
     else:
         # provide update if available. Note: this is also required while in state "running", otherwise swupdate
@@ -158,7 +158,7 @@ async def deployment_feedback(
 
             logger.debug(f"Installation failed, software={reported_software.version}, device={updater.dev_id}")
     else:
-        logging.warning(
+        logging.error(
             f"Device reported unhandled execution state, state={data.status.execution}, device={updater.dev_id}"
         )
 

--- a/goosebit/updater/controller/v1/routes.py
+++ b/goosebit/updater/controller/v1/routes.py
@@ -122,6 +122,7 @@ async def deployment_feedback(
         # From hawkBit docu: DDI defines also a status NONE which will not be interpreted by the update server
         # and handled like SUCCESS.
         if data.status.result.finished in [FeedbackStatusResultFinished.SUCCESS, FeedbackStatusResultFinished.NONE]:
+            await updater.deployment_action_success()
             await updater.update_device_state(UpdateStateEnum.FINISHED)
 
             # not guaranteed to be the correct rollout - see next comment.

--- a/goosebit/updater/controller/v1/routes.py
+++ b/goosebit/updater/controller/v1/routes.py
@@ -116,7 +116,6 @@ async def deployment_feedback(
 
     elif data.status.execution == FeedbackStatusExecutionState.CLOSED:
         await updater.update_force_update(False)
-        await updater.update_log_complete(True)
 
         reported_software = await Software.get_or_none(id=action_id)
 

--- a/goosebit/updater/controller/v1/routes.py
+++ b/goosebit/updater/controller/v1/routes.py
@@ -107,7 +107,11 @@ async def deployment_feedback(
     _: Request, data: FeedbackSchema, action_id: int, updater: UpdateManager = Depends(get_update_manager)
 ):
     if data.status.execution == FeedbackStatusExecutionState.PROCEEDING:
-        await updater.update_device_state(UpdateStateEnum.RUNNING)
+        device = await updater.get_device()
+        if device and device.last_state != UpdateStateEnum.RUNNING:
+            await updater.clear_log()
+            await updater.update_device_state(UpdateStateEnum.RUNNING)
+
         logger.debug(f"Installation in progress, device={updater.dev_id}")
 
     elif data.status.execution == FeedbackStatusExecutionState.CLOSED:

--- a/goosebit/updater/manager.py
+++ b/goosebit/updater/manager.py
@@ -77,6 +77,9 @@ class UpdateManager(ABC):
     async def update_log_complete(self, log_complete: bool):
         return
 
+    async def clear_log(self) -> None:
+        return
+
     async def get_rollout(self) -> Rollout | None:
         return None
 
@@ -284,10 +287,6 @@ class DeviceUpdateManager(UpdateManager):
         else:
             handling_type = HandlingType.FORCED
 
-            if device.log_complete:
-                await self.update_log_complete(False)
-                await self.clear_log()
-
         return handling_type, software
 
     async def update_log(self, log_data: str) -> None:
@@ -301,11 +300,6 @@ class DeviceUpdateManager(UpdateManager):
         matches = re.findall(r"Downloaded (\d+)%", log_data)
         if matches:
             device.progress = matches[-1]
-
-        if log_data.startswith("Installing Update Chunk Artifacts."):
-            # clear log
-            device.last_log = ""
-            await self.publish_log(None)
 
         if not log_data == "Skipped Update.":
             device.last_log += f"{log_data}\n"

--- a/goosebit/updater/manager.py
+++ b/goosebit/updater/manager.py
@@ -74,6 +74,9 @@ class UpdateManager(ABC):
     async def update_config_data(self, **kwargs):
         return
 
+    async def deployment_action_success(self):
+        return
+
     async def clear_log(self) -> None:
         return
 
@@ -226,6 +229,11 @@ class DeviceUpdateManager(UpdateManager):
 
         if modified:
             await self.save_device(device, update_fields=["hardware_id", "last_state", "sw_version"])
+
+    async def deployment_action_success(self):
+        device = await self.get_device()
+        device.progress = 100
+        await self.save_device(device, update_fields=["progress"])
 
     async def get_rollout(self) -> Rollout | None:
         device = await self.get_device()

--- a/goosebit/updater/manager.py
+++ b/goosebit/updater/manager.py
@@ -74,9 +74,6 @@ class UpdateManager(ABC):
     async def update_config_data(self, **kwargs):
         return
 
-    async def update_log_complete(self, log_complete: bool):
-        return
-
     async def clear_log(self) -> None:
         return
 
@@ -229,11 +226,6 @@ class DeviceUpdateManager(UpdateManager):
 
         if modified:
             await self.save_device(device, update_fields=["hardware_id", "last_state", "sw_version"])
-
-    async def update_log_complete(self, log_complete: bool):
-        device = await self.get_device()
-        device.log_complete = log_complete
-        await self.save_device(device, update_fields=["log_complete"])
 
     async def get_rollout(self) -> Rollout | None:
         device = await self.get_device()

--- a/goosebit/updater/manager.py
+++ b/goosebit/updater/manager.py
@@ -297,6 +297,7 @@ class DeviceUpdateManager(UpdateManager):
         if device.last_log is None:
             device.last_log = ""
 
+        # SWUpdate-specific log parsing to report progress
         matches = re.findall(r"Downloaded (\d+)%", log_data)
         if matches:
             device.progress = matches[-1]

--- a/goosebit/updater/manager.py
+++ b/goosebit/updater/manager.py
@@ -301,9 +301,8 @@ class DeviceUpdateManager(UpdateManager):
         if matches:
             device.progress = matches[-1]
 
-        if not log_data == "Skipped Update.":
-            device.last_log += f"{log_data}\n"
-            await self.publish_log(f"{log_data}\n")
+        device.last_log += f"{log_data}\n"
+        await self.publish_log(f"{log_data}\n")
 
         await self.save_device(device, update_fields=["progress", "last_log"])
 

--- a/goosebit/updater/manager.py
+++ b/goosebit/updater/manager.py
@@ -305,10 +305,7 @@ class DeviceUpdateManager(UpdateManager):
             device.last_log += f"{log_data}\n"
             await self.publish_log(f"{log_data}\n")
 
-        await self.save_device(
-            device,
-            update_fields=["progress", "last_log"],
-        )
+        await self.save_device(device, update_fields=["progress", "last_log"])
 
     async def clear_log(self) -> None:
         device = await self.get_device()


### PR DESCRIPTION
Goals of this PR

- Reduce dependency on SWUpdate-specific log parsing
- Simplify code in the space of log handling
- Introduce automated tests to check log handling. Ideally the test would rely on the WebSocket endpoint to do the assertions but failed to do so.

Not 100% if commit e1c94c843 could introduce a regression. @b-rowan do you know the background here?