### PR TITLE
Introduce OpenSSF Scorecard

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,56 @@
+name: Scorecard supply-chain security
+on:
+  # For Branch-Protection check. Only the default branch is supported. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
+  branch_protection_rule:
+  # To guarantee Maintained check is occasionally updated. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained
+  schedule:
+    - cron: "30 4 * * 0"
+  push:
+    branches:
+      - master
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload the results to code-scanning dashboard.
+      security-events: write
+      # Needed to publish results and get a badge (see publish_results below).
+      id-token: write
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@0864cf19026789058feabb7e87baa5f140aac736 # v2.3.1
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          # - Publish results to OpenSSF REST API for easy access by consumers
+          # - Allows the repository to include the Scorecard badge.
+          # - See https://github.com/ossf/scorecard-action#publishing-results.
+          publish_results: true
+
+      # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
+      # format to the repository Actions tab.
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@97a0fba1372883ab732affbe8f94b823f91727db # v3.pre.node20
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      # Upload the results to GitHub's code scanning dashboard (optional).
+      # Commenting out will disable upload of results to your repo's Code Scanning dashboard
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 <img src="docs/img/goosebit-logo.png" style="width: 100px; height: 100px; display: block;">
 
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/UpstreamDataInc/goosebit/badge)](https://scorecard.dev/viewer/?uri=github.com/UpstreamDataInc/goosebit)
+
 ---
 
 A simplistic, opinionated remote update server implementing hawkBit™'s [DDI API](https://eclipse.dev/hawkbit/apis/ddi_api/).


### PR DESCRIPTION
This allows users to quickly assess the supply-chain security, as judged by the [OpenSSF scorecard](https://scorecard.dev/), of this project.

While the score is not yet great, this scorecard will help the project to implement sensible improvements.

Unfortunately, the action will run only once the PR has been merged, as the check refuses to work on anything other the main branch, master in this case. Let's review extra carefully! 🤞

To check out how the reporting will look like, have a look at my fork:
- Scorecard: https://scorecard.dev/viewer/?uri=github.com/rettichschnidi/goosebit
- Badge: [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/rettichschnidi/goosebit/badge)](https://scorecard.dev/viewer/?uri=github.com/rettichschnidi/goosebit)

Alternatively, the checks can be run locally in CI:

```
docker run -e GITHUB_AUTH_TOKEN=<your GitHub PAT> gcr.io/openssf/scorecard:stable --show-details --repo=github.com/UpstreamDataInc/goosebit
```

The CLI actually tests this repository, instead of my fork. As a result, the resulting score is 5.6 and not 3.2.