### PR TITLE
Add uvicorn to Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,6 +8,7 @@ RUN addgroup -g 1000 goosebit && \
     chown goosebit:goosebit /artifacts && \
     pip install --no-cache-dir \
         gunicorn \
+        uvicorn \
         goosebit[postgresql]==$GOOSEBIT_VERSION
 
 COPY aerich.toml /


### PR DESCRIPTION
The Python package no longer seems to be a transient dependency.