### PR TITLE
Re-add uvicorn dependency

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,6 @@ RUN addgroup -g 1000 goosebit && \
     chown goosebit:goosebit /artifacts && \
     pip install --no-cache-dir \
         gunicorn \
-        uvicorn \
         goosebit[postgresql]==$GOOSEBIT_VERSION
 
 COPY aerich.toml /

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.11"
-fastapi = {extras = ["uvicorn"], version = "^0.115.4"}
+fastapi = "^0.115.4"
 python-multipart = "^0.0.17"
 jinja2 = "^3.1.4"
 itsdangerous = "^2.2.0"
@@ -24,6 +24,7 @@ opentelemetry-exporter-prometheus = "^0.49b1"
 aiocache = "^0.12.2"
 httpx = "^0.27.0"
 pydantic-settings = "^2.4.0"
+uvicorn = "^0.32.0"
 
 asyncpg = { version = "^0.30.0", optional = true }
 


### PR DESCRIPTION
The fastapi package no longer has an "uvicorn" extra. Explicitly add the dependency instead.

This seems to be needed since #186.
