### PR TITLE
Add index for software_id on rollout table 

### DIFF
--- a/goosebit/db/migrations/models/2_20241121113728_update.py
+++ b/goosebit/db/migrations/models/2_20241121113728_update.py
@@ -1,0 +1,11 @@
+from tortoise import BaseDBAsyncClient
+
+
+async def upgrade(db: BaseDBAsyncClient) -> str:
+    return """
+        CREATE INDEX "idx_rollout_software_3614e1" ON "rollout" ("software_id");"""
+
+
+async def downgrade(db: BaseDBAsyncClient) -> str:
+    return """
+        DROP INDEX "idx_rollout_software_3614e1";"""

--- a/goosebit/db/models.py
+++ b/goosebit/db/models.py
@@ -107,7 +107,7 @@ class Rollout(Model):
     created_at = fields.DatetimeField(auto_now_add=True)
     name = fields.CharField(max_length=255, null=True)
     feed = fields.CharField(max_length=255, default="default")
-    software = fields.ForeignKeyField("models.Software", related_name="rollouts")
+    software = fields.ForeignKeyField("models.Software", related_name="rollouts", index=True)
     paused = fields.BooleanField(default=False)
     success_count = fields.IntField(default=0)
     failure_count = fields.IntField(default=0)


### PR DESCRIPTION
Index can be used to speed up query generated during poll.