### PR TITLE
Fix Docker image

### DIFF
--- a/docker/aerich.toml
+++ b/docker/aerich.toml
@@ -1,3 +1,3 @@
 [tool.aerich]
 tortoise_orm = "goosebit.db.config.TORTOISE_CONF"
-location = "/usr/local/lib/python3.12/site-packages/goosebit/db/migrations"
+location = "/usr/local/lib/python3.13/site-packages/goosebit/db/migrations"


### PR DESCRIPTION
As we use Python 3.13 now, aerich.toml needs to be adapted.