### PR TITLE
Add Dockerfile for local development builds

### DIFF
--- a/docker/dev.dockerfile
+++ b/docker/dev.dockerfile
@@ -1,0 +1,27 @@
+FROM python:3.13.0-alpine@sha256:fcbcbbecdeae71d3b77445d9144d1914df55110f825ab62b04a66c7c33c09373
+
+COPY . /tmp/src
+
+RUN addgroup -g 1000 goosebit && \
+    adduser -u 1000 -G goosebit -s /bin/sh -D goosebit && \
+    mkdir /artifacts && \
+    chown goosebit:goosebit /artifacts && \
+    pip install --no-cache-dir \
+        gunicorn \
+        /tmp/src[postgresql] && \
+    rm -rf /tmp/src
+
+COPY docker/aerich.toml /
+
+VOLUME /artifacts
+
+EXPOSE 60053
+
+USER goosebit
+
+# We currently do not fully support multiple workers. For more information, see:
+# https://github.com/UpstreamDataInc/goosebit/issues/125
+ENV GUNICORN_CMD_ARGS="--workers 1 --enable-stdio-inheritance"
+
+CMD aerich --config /aerich.toml upgrade && \
+    gunicorn --worker-class uvicorn.workers.UvicornWorker --bind 0.0.0.0:60053 goosebit:app </dev/null


### PR DESCRIPTION
For testing/development purposes, a Docker image can be built, for the currently checked out code, with:

    docker build -t upstreamdata/goosebit -f docker/dev.dockerfile .

And to start the container, simply run:

    docker compose -f docker/demo/docker-compose.yml up