### PR TITLE
Reduce automatic update frequency of dependabot to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,17 @@
 version: 2
 updates:
-  - package-ecosystem: "pip"
-    directory: "/"
+  - package-ecosystem: pip
+    directory: /
     schedule:
-      interval: "weekly"
+      interval: monthly
     open-pull-requests-limit: 5
 
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: daily
+      interval: monthly
 
   - package-ecosystem: docker
     directory: /docker
     schedule:
-      interval: daily
+      interval: monthly


### PR DESCRIPTION
Looks like most of the energy goes towards updating dependencies and not into stabilization / features / documentation.

A monthly frequency IMHO should be sufficient as well.