### PR TITLE
bug: remove responsive from tables

### DIFF
--- a/goosebit/ui/static/js/devices.js
+++ b/goosebit/ui/static/js/devices.js
@@ -40,7 +40,6 @@ document.addEventListener("DOMContentLoaded", async () => {
     }
 
     dataTable = new DataTable("#device-table", {
-        responsive: true,
         paging: true,
         processing: false,
         serverSide: true,

--- a/goosebit/ui/static/js/rollouts.js
+++ b/goosebit/ui/static/js/rollouts.js
@@ -26,7 +26,6 @@ document.addEventListener("DOMContentLoaded", async () => {
     }
 
     dataTable = new DataTable("#rollout-table", {
-        responsive: true,
         paging: true,
         processing: true,
         serverSide: true,

--- a/goosebit/ui/static/js/software.js
+++ b/goosebit/ui/static/js/software.js
@@ -80,7 +80,6 @@ document.addEventListener("DOMContentLoaded", async () => {
     }
 
     dataTable = new DataTable("#software-table", {
-        responsive: true,
         paging: true,
         processing: false,
         serverSide: true,


### PR DESCRIPTION
This setting was causing the user selection to get reset and the table to scroll to the top on every redraw.