### PR TITLE
Add commitlint to check commit messages

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,3 +64,9 @@ repos:
     rev: v8.24.3
     hooks:
       - id: gitleaks
+  - repo: https://github.com/alessandrojcm/commitlint-pre-commit-hook
+    rev: v9.22.0
+    hooks:
+      - id: commitlint
+        stages: [commit-msg]
+        additional_dependencies: ["@commitlint/config-conventional"]

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Code is linted using different tools as well
 Best to have pre-commit install git hooks that run all those tools before a commit:
 
 ```bash
-poetry run pre-commit install
+poetry run pre-commit install --hook-type pre-commit --hook-type commit-msg
 ```
 
 To manually apply the hooks to all files use:

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,0 +1,3 @@
+export default {
+    extends: ["@commitlint/config-conventional"],
+};


### PR DESCRIPTION
Implements `commitlint` as proposed in #110.

Opted to use rule set "@commitlint/config-conventional". This should implement (in my understanding) https://www.conventionalcommits.org/en/v1.0.0/ . 

Note: this differs to our previous rules in the following way
1. Mandates to use a `type` prefix
2. Mandates to write lower-case description

@easybe what do you think of https://www.conventionalcommits.org