### PR TITLE
fix: update OctKey importing path

### DIFF
--- a/goosebit/settings/schema.py
+++ b/goosebit/settings/schema.py
@@ -4,7 +4,7 @@ from enum import StrEnum
 from pathlib import Path
 from typing import Annotated
 
-from joserfc.rfc7518.oct_key import OctKey
+from joserfc.jwk import OctKey
 from pydantic import BaseModel, BeforeValidator
 from pydantic_settings import (
     BaseSettings,


### PR DESCRIPTION
The `rfcXXX` folders will be converted into private modules. It is recommended to import OctKey from `joserfc.jwk`.