### PR TITLE
fix(s3): fallback as default in case S3 service is not exposed externally

### DIFF
--- a/goosebit/ui/bff/download/routes.py
+++ b/goosebit/ui/bff/download/routes.py
@@ -23,7 +23,7 @@ async def download_file(_: Request, file_id: int):
     try:
         url = await storage.get_download_url(software.uri)
         return RedirectResponse(url=url)
-    except Exception:
+    except ValueError:
         # Fallback to streaming if redirect fails.
         file_stream = storage.get_file_stream(software.uri)
         return StreamingResponse(


### PR DESCRIPTION
Today we deployed goosebit with minio in kubernetes cluster and encountered this issue that file on S3 can be uploaded but not downloadable via web UI, neither devices could download it, because we don't have minio exposed externally.

This PR fixes that, all files handled by external S3 service are fallbacking to streaming by default and goosebit handles that properly now.