### PR TITLE
Rework plugin READMEs

### DIFF
--- a/.prettierrc.yaml
+++ b/.prettierrc.yaml
@@ -2,6 +2,7 @@ useTabs: false
 tabWidth: 4
 overrides:
   - files:
+      - "**/*.md"
       - "**/*.yaml"
       - "**/*.yml"
     options:

--- a/README.md
+++ b/README.md
@@ -230,10 +230,10 @@ The structure of gooseBit is as follows:
 
 - `api`: Files for the API.
 - `ui`: Files for the UI.
-    - `bff`: Backend for frontend API.
-    - `static`: Static files.
-    - `templates`: Jinja2 formatted templates.
-    - `nav`: Navbar handler.
+  - `bff`: Backend for frontend API.
+  - `static`: Static files.
+  - `templates`: Jinja2 formatted templates.
+  - `nav`: Navbar handler.
 - `updater`: DDI API handler and device update manager.
 - `updates`: SWUpdate file parsing.
 - `auth`: Authentication functions and permission handling.

--- a/plugins/goosebit_forwarded_header/README.md
+++ b/plugins/goosebit_forwarded_header/README.md
@@ -6,23 +6,19 @@ support the feature (yet): [uvicorn#2237]
 
 [uvicorn#2237]: https://github.com/encode/uvicorn/issues/2237
 
-## Setup
+## Installation
 
-### Installation
+E.g. in Dockerfile, install with pip:
 
-1. Load the plugin into poetry env (in goosebit):
+```txt
+pip install goosebit-forwarded-header
+```
 
-    ```txt
-    poetry install --with goosebit_forwarded_header
-    ```
+## Configuration
 
-### Configuration
+Enable the plugin in `goosebit.yaml`:
 
-1. Enable the plugin in `goosebit.yaml`:
-
-    ```yaml
-    plugins:
-        - goosebit_forwarded_header
-    ```
-
-2. Run gooseBit as normal.
+```yaml
+plugins:
+  - goosebit_forwarded_header
+```

--- a/plugins/goosebit_simple_stats/README.md
+++ b/plugins/goosebit_simple_stats/README.md
@@ -4,31 +4,27 @@ A simple example plugin for testing and understanding gooseBit's plugin system.
 
 This plugin sets up a page which shows software count and/or device count.
 
-## Setup
+## Installation
 
-### Installation
+E.g. in Dockerfile, install with pip:
 
-1. Load the plugin into poetry env (in goosebit):
+```txt
+pip install goosebit-simple-stats
+```
 
-    ```txt
-    poetry install --with goosebit_simple_stats
-    ```
+## Configuration
 
-### Configuration
+Enable the plugin in `goosebit.yaml`:
 
-1. Enable the plugin in `goosebit.yaml`:
+```yaml
+plugins:
+  - goosebit_simple_stats
+```
 
-    ```yaml
-    plugins:
-        - goosebit_simple_stats
-    ```
+Configure which data to show:
 
-2. Configure the plugin:
-
-    ```yaml
-    simple_stats_show:
-        - device_count
-        - software_count
-    ```
-
-3. Run gooseBit as normal.
+```yaml
+simple_stats_show:
+  - device_count
+  - software_count
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "goosebit"
-version = "0.2.6"
+version = "0.2.7"
 description = ""
 authors = [
     {name = "Brett Rowan", email = "121075405+b-rowan@users.noreply.github.com"}


### PR DESCRIPTION
Plugins can soon be installed with pip.

---

As the plugins are not marked as optional in the main pyproject.toml (which IMHO is fine), they are automatically installed when running `poetry install`. So, I don't think it's necessary to document the Poetry use case here.

As the content of these READMEs is also uploaded to PyPI (https://test.pypi.org/project/goosebit-simple-stats/), we should rather document how to install from package.

If you disagree, I am open to suggestions.