### PR TITLE
Make HW revision support optional for RAUC

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ The software packages managed by gooseBit are either stored on the local filesys
 - Devices use [SWUpdate](https://swupdate.org) or [RAUC](https://rauc.io) + [RAUC hawkBit Updater](https://rauc-hawkbit-updater.readthedocs.io) for managing software updates.
 - Devices send certain attributes (`sw_version`, `hw_boardname`, `hw_revision`).
 - Semantic versions are used.
-- With RAUC and multiple hardware revisions, `compatible` in `manifest.raucm` is set to something like `my-board-rev4.2` or `Some Board 2b`.
 
 ## Features
 

--- a/conftest.py
+++ b/conftest.py
@@ -11,10 +11,14 @@ from httpx import ASGITransport, AsyncClient
 from tortoise import Tortoise
 from tortoise.contrib.fastapi import RegisterTortoise
 
-from goosebit import app
-from goosebit.auth.permissions import GOOSEBIT_PERMISSIONS
-from goosebit.db.models import UpdateModeEnum, UpdateStateEnum
-from goosebit.settings import PWD_CXT  # type: ignore[attr-defined]
+# Configuring rauc_compatible_pattern for tests/unit/updates/rauc/test_swdesc.py here, as we do not want to have it set
+# in goosebit.yaml.
+os.environ["GOOSEBIT_RAUC_COMPATIBLE_PATTERN"] = r"^(?P<hw_boardname>.+?)(-(?P<hw_revision>\w*[\d.]+\w*))?$"
+
+from goosebit import app  # noqa: E402
+from goosebit.auth.permissions import GOOSEBIT_PERMISSIONS  # noqa: E402
+from goosebit.db.models import UpdateModeEnum, UpdateStateEnum  # noqa: E402
+from goosebit.settings import PWD_CXT  # type: ignore[attr-defined]  # noqa: E402
 
 # Configure logging
 logging.basicConfig(level=logging.WARN)

--- a/goosebit.yaml
+++ b/goosebit.yaml
@@ -59,6 +59,12 @@ poll_time: 00:01:00
 # Defaults to a randomized value. If this value is not set, user sessions will not persist when app restarts.
 #secret_key: my_very_top_secret_key123
 
+# Regular expression to extract board name and revision from RAUC compatible string.
+# HW revision support is disabled by default when using RAUC.
+# By uncommenting the following line, the last part of the compatible string, separated by a hyphen, will be
+# interpreted as the HW revision, e.g.: myboard-rev1.0a
+#rauc_compatible_pattern: ^(?P<hw_boardname>.+?)(-(?P<hw_revision>\w*[\d.]+\w*))?$
+
 # A list of installed plugins that you want to enable in gooseBit
 #plugins:
 #  - goosebit_simple_stats

--- a/goosebit/settings/schema.py
+++ b/goosebit/settings/schema.py
@@ -101,6 +101,8 @@ class GooseBitSettings(BaseSettings):
 
     track_device_ip: bool = True
 
+    rauc_compatible_pattern: str | None = None
+
     @field_validator("secret_key", mode="before")
     @classmethod
     def import_secret_key(cls, v: Any) -> OctKey:


### PR DESCRIPTION
HW revision support is now disabled by default when using RAUC. To
use the feature, rauc_compatible_pattern needs to be configured in the
settings.
