### PR TITLE
feat: mask passwords in software URLs displayed in UI

### DIFF
--- a/goosebit/schema/software.py
+++ b/goosebit/schema/software.py
@@ -1,10 +1,23 @@
 from __future__ import annotations
 
-from urllib.parse import unquote, urlparse
+from urllib.parse import unquote, urlparse, urlunparse
 from urllib.request import url2pathname
 
 from anyio import Path
 from pydantic import BaseModel, ConfigDict, Field, computed_field
+
+
+def mask_url_password(url: str) -> str:
+    """Mask password in URL for display purposes."""
+    parsed = urlparse(url)
+    if parsed.password:
+        # Reconstruct netloc with masked password
+        if parsed.port:
+            netloc = f"{parsed.username}:***@{parsed.hostname}:{parsed.port}"
+        else:
+            netloc = f"{parsed.username}:***@{parsed.hostname}"
+        return urlunparse(parsed._replace(netloc=netloc))
+    return url
 
 
 class HardwareSchema(BaseModel):
@@ -39,4 +52,4 @@ class SoftwareSchema(BaseModel):
         if self.local:
             return self.path.name
         else:
-            return self.uri
+            return mask_url_password(self.uri)

--- a/tests/unit/schema/test_software.py
+++ b/tests/unit/schema/test_software.py
@@ -1,0 +1,29 @@
+import pytest
+
+from goosebit.schema.software import mask_url_password
+
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        # URL without password - unchanged
+        ("https://example.com/firmware.swu", "https://example.com/firmware.swu"),
+        ("http://example.com/path/to/file.swu", "http://example.com/path/to/file.swu"),
+        # URL with username only - unchanged
+        ("https://user@example.com/firmware.swu", "https://user@example.com/firmware.swu"),
+        # URL with username and password - password masked
+        ("https://user:secret@example.com/firmware.swu", "https://user:***@example.com/firmware.swu"),
+        ("http://admin:p4ssw0rd@server.local/path/file.swu", "http://admin:***@server.local/path/file.swu"),
+        # URL with credentials and port
+        ("https://user:secret@example.com:8443/firmware.swu", "https://user:***@example.com:8443/firmware.swu"),
+        # URL with special characters in password
+        ("https://user:p%40ss%3Aword@example.com/fw.swu", "https://user:***@example.com/fw.swu"),
+        # S3 URL without credentials - unchanged
+        ("s3://bucket/path/to/firmware.swu", "s3://bucket/path/to/firmware.swu"),
+        # File URL - unchanged
+        ("file:///path/to/firmware.swu", "file:///path/to/firmware.swu"),
+    ],
+)
+def test_mask_url_password(url: str, expected: str) -> None:
+    """Test that passwords in URLs are correctly masked."""
+    assert mask_url_password(url) == expected


### PR DESCRIPTION
When displaying remote software URLs in lists, passwords are now masked with '***' to prevent accidental exposure of credentials.

The original URL with credentials is preserved in the database and is still passed to devices for authentication.